### PR TITLE
feat(agent): implement tab session isolation with concurrent streaming

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -14,6 +14,7 @@ import { SettingsModal } from "./components/settings";
 import { useAutosave } from "./hooks/useAutosave";
 import { useColorScheme } from "./hooks/useColorScheme";
 import { useTitlebarStyle } from "./hooks/usePlatform";
+import { initializeAgentStreamListener } from "./hooks/useAgentStream";
 import { SIDEBAR } from "./lib/constants";
 import { cn } from "./lib/utils";
 
@@ -66,9 +67,10 @@ function AppContent() {
     });
   }, [initializeProviders]);
 
-  // Load persisted agent sessions on startup
+  // Load persisted agent sessions and initialize stream listener on startup
   useEffect(() => {
     loadPersistedSessions();
+    initializeAgentStreamListener();
   }, [loadPersistedSessions]);
 
   // Open a file in the panel system

--- a/apps/desktop/src/components/agent/AgentWindow.tsx
+++ b/apps/desktop/src/components/agent/AgentWindow.tsx
@@ -5,7 +5,6 @@ import { MessageFeed } from './messages';
 import { ChatInputContainer } from './input';
 import { convertToMessageGroups } from './messageAdapter';
 import { useAgentSession } from '../../hooks/useAgentSession';
-import { useAgentStream } from '../../hooks/useAgentStream';
 import { useProviderStore } from '../../stores/provider-store';
 import { usePanelTabsStore } from '../../stores/panelTabsStore';
 import { BUILTIN_PANEL_TYPES } from '../../lib/panels/builtinPanels';
@@ -44,39 +43,15 @@ export interface AgentWindowProps {
  *
  * This component provides a complete chat interface for the AI agent.
  * It can be used as a standalone panel or embedded in React Mosaic.
- *
- * @example
- * ```tsx
- * // Basic usage
- * <AgentWindow instanceId="agent-1" />
- *
- * // With callbacks
- * <AgentWindow
- *   instanceId="agent-2"
- *   callbacks={{
- *     onFileOpen: (path) => openEditor(path),
- *   }}
- * />
- *
- * // In React Mosaic
- * const tabFactory = (id) => {
- *   if (id.startsWith('agent-')) {
- *     return <AgentWindow instanceId={id} />;
- *   }
- * };
- * ```
  */
 export const AgentWindow: FC<AgentWindowProps> = ({
 	instanceId,
-	initialSessionId: _initialSessionId, // Reserved for future session restoration
+	initialSessionId,
 	callbacks,
-	ui: _ui = {}, // Reserved for future UI customization
+	ui: _ui = {},
 	className = '',
 }) => {
-	// Enable stream listening for this window
-	useAgentStream({ enabled: true });
-
-	// Session management
+	// Session management — scoped to this tab's session
 	const {
 		sessionId,
 		messages,
@@ -86,7 +61,9 @@ export const AgentWindow: FC<AgentWindowProps> = ({
 		sendMessage,
 		clearError,
 	} = useAgentSession({
-		autoCreate: true,
+		sessionId: initialSessionId ?? null,
+		autoCreate: !initialSessionId,
+		defaultModel: useProviderStore((state) => state.selectedModel) || undefined,
 	});
 
 	// Provider state for model selection
@@ -94,6 +71,13 @@ export const AgentWindow: FC<AgentWindowProps> = ({
 
 	// Panel system for opening new tabs
 	const openPanel = usePanelTabsStore((state) => state.openPanel);
+
+	// When auto-created, sync session ID back to panel data
+	useEffect(() => {
+		if (sessionId && !initialSessionId) {
+			usePanelTabsStore.getState().updateData(instanceId, { sessionId });
+		}
+	}, [sessionId, initialSessionId, instanceId]);
 
 	// Convert messages to message groups for the new MessageFeed
 	const messageGroups = useMemo(

--- a/apps/desktop/src/components/agent/SessionList.tsx
+++ b/apps/desktop/src/components/agent/SessionList.tsx
@@ -3,8 +3,11 @@
  * Shows all sessions with ability to create new ones and switch between them
  */
 
+import { useRef } from 'react';
 import { Plus, MessageSquare } from 'lucide-react';
-import { useSessions, useActiveSessionId } from '@/stores/agentStore';
+import { useAgentStore, useSessions, useActiveSessionId } from '@/stores/agentStore';
+import { usePanelTabsStore } from '@/stores/panelTabsStore';
+import { BUILTIN_PANEL_TYPES } from '@/lib/panels';
 import { cn } from '@/lib/utils';
 
 import type { FC } from 'react';
@@ -18,6 +21,66 @@ export interface SessionListProps {
   readonly className?: string;
 }
 
+const EMPTY_SET = new Set<string>();
+
+/**
+ * Compute the set of session IDs that currently have open tabs.
+ * Uses useRef to return a stable reference for React 19 compatibility.
+ */
+function useOpenSessionIds(): Set<string> {
+  const prevRef = useRef<{ key: string; result: Set<string> }>({ key: '', result: EMPTY_SET });
+
+  return usePanelTabsStore((state) => {
+    // Build a sorted key of open agent session IDs
+    const ids: string[] = [];
+    for (const instance of state.instances.values()) {
+      if (instance.panelType === BUILTIN_PANEL_TYPES.AGENT) {
+        const sid = (instance.data as Record<string, unknown>)?.sessionId;
+        if (typeof sid === 'string') {
+          ids.push(sid);
+        }
+      }
+    }
+    ids.sort();
+    const key = ids.join(',');
+
+    if (key === prevRef.current.key) {
+      return prevRef.current.result;
+    }
+
+    const result = new Set(ids);
+    prevRef.current = { key, result };
+    return result;
+  });
+}
+
+/**
+ * Compute the set of session IDs that are currently streaming.
+ * Uses useRef to return a stable reference for React 19 compatibility.
+ */
+function useStreamingSessionIds(): Set<string> {
+  const prevRef = useRef<{ key: string; result: Set<string> }>({ key: '', result: EMPTY_SET });
+
+  return useAgentStore((state) => {
+    const ids: string[] = [];
+    for (const [sessionId, streamState] of state.sessionStreaming.entries()) {
+      if (streamState.isStreaming) {
+        ids.push(sessionId);
+      }
+    }
+    ids.sort();
+    const key = ids.join(',');
+
+    if (key === prevRef.current.key) {
+      return prevRef.current.result;
+    }
+
+    const result = new Set(ids);
+    prevRef.current = { key, result };
+    return result;
+  });
+}
+
 /**
  * Compact session list component for sidebar
  * Displays all sessions and allows creating new ones
@@ -29,6 +92,8 @@ export const SessionList: FC<SessionListProps> = ({
 }) => {
   const sessions = useSessions();
   const activeSessionId = useActiveSessionId();
+  const streamingIds = useStreamingSessionIds();
+  const openSessionIds = useOpenSessionIds();
 
   // Empty state - centered like Explorer
   if (sessions.length === 0) {
@@ -64,29 +129,44 @@ export const SessionList: FC<SessionListProps> = ({
       {/* Session List */}
       <div className="flex-1 overflow-y-auto p-2">
         <div className="space-y-1">
-          {sessions.map((session) => (
-            <button
-              key={session.id}
-              onClick={() => onSessionSelect(session.id)}
-              className={cn(
-                'w-full px-3 py-2 flex items-center gap-2 rounded-lg text-left transition-all duration-150',
-                'hover:bg-muted/60 hover:scale-[1.02] active:scale-[0.97]',
-                activeSessionId === session.id
-                  ? 'bg-muted text-foreground'
-                  : 'text-muted-foreground hover:text-foreground'
-              )}
-            >
-              <MessageSquare className="h-4 w-4 shrink-0" />
-              <div className="flex-1 min-w-0">
-                <span className="text-sm truncate block">
-                  {formatSessionDate(session.createdAt)}
-                </span>
-                <span className="text-xs text-muted-foreground/60 truncate block">
-                  {session.model.split('-').slice(0, 2).join(' ')}
-                </span>
-              </div>
-            </button>
-          ))}
+          {sessions.map((session) => {
+            const isStreaming = streamingIds.has(session.id);
+            const hasOpenTab = openSessionIds.has(session.id);
+
+            return (
+              <button
+                key={session.id}
+                onClick={() => onSessionSelect(session.id)}
+                className={cn(
+                  'w-full px-3 py-2 flex items-center gap-2 rounded-lg text-left transition-all duration-150',
+                  'hover:bg-muted/60 hover:scale-[1.02] active:scale-[0.97]',
+                  activeSessionId === session.id
+                    ? 'bg-muted text-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                {/* Streaming indicator — pulsing dot */}
+                {isStreaming && (
+                  <span className="w-2 h-2 rounded-full bg-primary animate-pulse shrink-0" />
+                )}
+
+                <MessageSquare
+                  className={cn(
+                    'h-4 w-4 shrink-0',
+                    hasOpenTab ? 'text-primary' : ''
+                  )}
+                />
+                <div className="flex-1 min-w-0">
+                  <span className="text-sm truncate block">
+                    {formatSessionDate(session.createdAt)}
+                  </span>
+                  <span className="text-xs text-muted-foreground/60 truncate block">
+                    {session.model.split('-').slice(0, 2).join(' ')}
+                  </span>
+                </div>
+              </button>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/apps/desktop/src/components/panels/AgentPanel.tsx
+++ b/apps/desktop/src/components/panels/AgentPanel.tsx
@@ -37,9 +37,17 @@ function getSessionTitle(sessionId: string | undefined): string {
 export function AgentPanel({
   instanceId,
   data,
+  isActive,
   onTitleChange,
 }: PanelProps<AgentPanelData>) {
   const sessionId = data?.sessionId;
+
+  // Sync activeSessionId when this tab is focused
+  useEffect(() => {
+    if (isActive && sessionId) {
+      useAgentStore.getState().setActiveSession(sessionId);
+    }
+  }, [isActive, sessionId]);
 
   // Update title based on session content
   useEffect(() => {

--- a/apps/desktop/src/components/panels/Tab.tsx
+++ b/apps/desktop/src/components/panels/Tab.tsx
@@ -9,6 +9,8 @@ import { X, Pin } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { PanelInstance, TileId, PanelInstanceId, TabDragItem } from '@/lib/panels/types';
 import { DragItemTypes } from '@/lib/panels/types';
+import { useIsSessionStreaming } from '@/stores/agentStore';
+import { BUILTIN_PANEL_TYPES } from '@/lib/panels/builtinPanels';
 
 interface TabProps {
   instance: PanelInstance;
@@ -117,6 +119,13 @@ export function Tab({
     drop(node);
   };
 
+  // Check if this is a streaming agent tab
+  const isAgentTab = instance.panelType === BUILTIN_PANEL_TYPES.AGENT;
+  const agentSessionId = isAgentTab
+    ? ((instance.data as Record<string, unknown>)?.sessionId as string | undefined) ?? null
+    : null;
+  const isSessionCurrentlyStreaming = useIsSessionStreaming(agentSessionId);
+
   return (
     <div
       ref={combinedRef}
@@ -139,10 +148,12 @@ export function Tab({
       onMouseDown={handleMouseDown}
       onContextMenu={handleContextMenu}
     >
-      {/* Dirty indicator */}
-      {instance.isDirty && (
+      {/* Streaming indicator (pulsing dot) takes priority over dirty indicator */}
+      {isSessionCurrentlyStreaming ? (
+        <span className="w-2 h-2 rounded-full bg-primary animate-pulse shrink-0" />
+      ) : instance.isDirty ? (
         <span className="w-1.5 h-1.5 rounded-full bg-primary shrink-0" />
-      )}
+      ) : null}
 
       {/* Tab title */}
       <span className="text-sm truncate flex-1">{instance.title}</span>

--- a/apps/desktop/src/components/sidebar/PrimarySidebar.tsx
+++ b/apps/desktop/src/components/sidebar/PrimarySidebar.tsx
@@ -25,10 +25,9 @@ export const PrimarySidebar: FC<PrimarySidebarProps> = ({ width, onFileOpen }) =
   const isCollapsed = useIsLeftSidebarCollapsed();
   const activeTab = useUIStore((state) => state.activeTab);
   const setActiveTab = useUIStore((state) => state.setActiveTab);
-  const setActiveSession = useAgentStore((state) => state.setActiveSession);
   const createSession = useAgentStore((state) => state.createSession);
 
-  // Get openPanel action directly from store to avoid selector subscription issues
+  // Get store actions directly to avoid selector subscription issues
   const openPanel = useMemo(() => usePanelTabsStore.getState().openPanel, []);
 
   // Provider/credentials state
@@ -36,11 +35,26 @@ export const PrimarySidebar: FC<PrimarySidebarProps> = ({ width, onFileOpen }) =
   const hasCredentials = useHasCredentials(activeProvider ?? 'anthropic');
   const [showApiKeyDialog, setShowApiKeyDialog] = useState(false);
 
-  // Open a session as a tab in the panel system
+  // Open a session as a tab — find existing tab first, otherwise open new
   const handleSessionSelect = useCallback((sessionId: string): void => {
-    setActiveSession(sessionId);
+    const store = usePanelTabsStore.getState();
+    // Search for an existing agent panel with this session
+    for (const [instanceId, instance] of store.instances.entries()) {
+      if (
+        instance.panelType === BUILTIN_PANEL_TYPES.AGENT &&
+        (instance.data as Record<string, unknown>)?.sessionId === sessionId
+      ) {
+        // Found existing tab — activate it
+        const tileId = store.findTileForPanel(instanceId);
+        if (tileId) {
+          store.setActiveTab(tileId, instanceId);
+          return;
+        }
+      }
+    }
+    // No existing tab found — open a new one
     openPanel(BUILTIN_PANEL_TYPES.AGENT, { sessionId });
-  }, [setActiveSession, openPanel]);
+  }, [openPanel]);
 
   // Create session and open as tab
   const createSessionAndShow = useCallback((): void => {

--- a/apps/desktop/src/hooks/index.ts
+++ b/apps/desktop/src/hooks/index.ts
@@ -3,6 +3,6 @@
  */
 
 export { useAgentSession, type UseAgentSessionOptions, type UseAgentSessionReturn } from './useAgentSession';
-export { useAgentStream, useAgentSessionWithStream, type UseAgentStreamOptions } from './useAgentStream';
+export { initializeAgentStreamListener, teardownAgentStreamListener } from './useAgentStream';
 export { useAutosave } from './useAutosave';
 export { useParseResults } from './useParseResults';

--- a/apps/desktop/src/hooks/useAgentSession.ts
+++ b/apps/desktop/src/hooks/useAgentSession.ts
@@ -2,14 +2,22 @@
  * Hook for managing agent sessions
  *
  * Provides session lifecycle management and message sending.
+ * Accepts an explicit sessionId for tab-scoped usage.
  */
 
-import { useCallback, useEffect, useRef } from 'react';
-import { useAgentStore, useActiveSession, useActiveSessionId, useActiveSessionMessages } from '../stores/agentStore';
-import type { MessageMode } from '../stores/agentStore';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+	useAgentStore,
+	useSessionMessages,
+	useIsSessionStreaming,
+	useSessionError,
+} from '../stores/agentStore';
+import type { Message, MessageMode, AgentSession } from '../stores/agentStore';
 
 export interface UseAgentSessionOptions {
-	/** Auto-create a session if none exists */
+	/** Explicit session ID to use (from tab data) */
+	sessionId: string | null;
+	/** Auto-create a session if sessionId is null */
 	autoCreate?: boolean;
 	/** Default model for new sessions */
 	defaultModel?: string;
@@ -17,11 +25,11 @@ export interface UseAgentSessionOptions {
 
 export interface UseAgentSessionReturn {
 	/** Current session */
-	session: ReturnType<typeof useActiveSession>;
+	session: AgentSession | null;
 	/** Current session ID */
 	sessionId: string | null;
 	/** Messages in the current session */
-	messages: ReturnType<typeof useActiveSessionMessages>;
+	messages: Message[];
 	/** Whether the agent is currently processing */
 	isRunning: boolean;
 	/** Current error message */
@@ -35,38 +43,25 @@ export interface UseAgentSessionReturn {
 }
 
 /**
- * Hook for managing agent sessions
- *
- * @example
- * ```tsx
- * function ChatPanel() {
- *   const { session, messages, sendMessage, isRunning } = useAgentSession({
- *     autoCreate: true,
- *   });
- *
- *   const handleSubmit = (content: string) => {
- *     sendMessage(content, 'planning');
- *   };
- *
- *   return (
- *     <div>
- *       {messages.map(msg => <Message key={msg.id} {...msg} />)}
- *       <Input onSubmit={handleSubmit} disabled={isRunning} />
- *     </div>
- *   );
- * }
- * ```
+ * Hook for managing agent sessions, scoped to a specific session ID.
  */
 export function useAgentSession(
-	options: UseAgentSessionOptions = {}
+	options: UseAgentSessionOptions
 ): UseAgentSessionReturn {
-	const { autoCreate = false, defaultModel } = options;
+	const { sessionId: propSessionId, autoCreate = false, defaultModel } = options;
 
-	const session = useActiveSession();
-	const sessionId = useActiveSessionId();
-	const messages = useActiveSessionMessages();
-	const isRunning = useAgentStore((state) => state.isAgentRunning);
-	const error = useAgentStore((state) => state.error);
+	// Local session ID for auto-created sessions
+	const [localSessionId, setLocalSessionId] = useState<string | null>(null);
+	const effectiveSessionId = propSessionId ?? localSessionId;
+
+	// Session data from store
+	const sessions = useAgentStore((state) => state.sessions);
+	const session = effectiveSessionId ? sessions.get(effectiveSessionId) ?? null : null;
+
+	// Per-session messages and streaming state
+	const messages = useSessionMessages(effectiveSessionId);
+	const isRunning = useIsSessionStreaming(effectiveSessionId);
+	const error = useSessionError(effectiveSessionId);
 
 	const storeCreateSession = useAgentStore((state) => state.createSession);
 	const storeSendMessage = useAgentStore((state) => state.sendMessage);
@@ -75,13 +70,17 @@ export function useAgentSession(
 	// Track if we've attempted auto-creation
 	const autoCreated = useRef(false);
 
-	// Auto-create session if requested
+	// Auto-create session if requested and no session ID provided
 	useEffect(() => {
-		if (autoCreate && !sessionId && !autoCreated.current) {
+		if (autoCreate && !propSessionId && !localSessionId && !autoCreated.current) {
 			autoCreated.current = true;
-			storeCreateSession(defaultModel).catch(console.error);
+			storeCreateSession(defaultModel)
+				.then((newId) => {
+					setLocalSessionId(newId);
+				})
+				.catch(console.error);
 		}
-	}, [autoCreate, sessionId, defaultModel, storeCreateSession]);
+	}, [autoCreate, propSessionId, localSessionId, defaultModel, storeCreateSession]);
 
 	const createSession = useCallback(
 		async (model?: string) => {
@@ -92,19 +91,21 @@ export function useAgentSession(
 
 	const sendMessage = useCallback(
 		async (content: string, mode: MessageMode = 'planning') => {
-			if (!content.trim()) return;
-			await storeSendMessage(content, mode);
+			if (!content.trim() || !effectiveSessionId) return;
+			await storeSendMessage(effectiveSessionId, content, mode);
 		},
-		[storeSendMessage]
+		[storeSendMessage, effectiveSessionId]
 	);
 
 	const clearError = useCallback(() => {
-		storeClearError();
-	}, [storeClearError]);
+		if (effectiveSessionId) {
+			storeClearError(effectiveSessionId);
+		}
+	}, [storeClearError, effectiveSessionId]);
 
 	return {
 		session,
-		sessionId,
+		sessionId: effectiveSessionId,
 		messages,
 		isRunning,
 		error,

--- a/apps/desktop/src/hooks/useAgentStream.ts
+++ b/apps/desktop/src/hooks/useAgentStream.ts
@@ -1,124 +1,59 @@
 /**
- * Hook for listening to agent streaming events
+ * Singleton agent stream listener
  *
- * Automatically connects to the Tauri event system and updates the agent store.
+ * Sets up ONE Tauri event listener for all agent streaming events.
+ * Dispatches to the agent store's per-session handlers.
  */
 
-import { useEffect, useRef } from 'react';
 import { useAgentStore } from '../stores/agentStore';
 import { listenToAgentEvents, type AgentEventHandlers } from '../lib/tauri/agent';
 
-export interface UseAgentStreamOptions {
-	/** Whether to enable the stream listener */
-	enabled?: boolean;
-}
+let _initialized = false;
+let _cleanup: (() => void) | null = null;
 
 /**
- * Hook that listens to agent streaming events and updates the store
- *
- * This hook should be used at the top level of your agent UI to ensure
- * all streaming events are captured and the store is updated.
- *
- * @example
- * ```tsx
- * function AgentWindow() {
- *   // This hook automatically updates the agent store with streaming events
- *   useAgentStream({ enabled: true });
- *
- *   const messages = useActiveSessionMessages();
- *   // Messages will automatically update as chunks arrive
- *
- *   return <MessageFeed messages={messages} />;
- * }
- * ```
+ * Initialize the singleton agent stream listener.
+ * Safe to call multiple times — only the first call sets up the listener.
  */
-export function useAgentStream(options: UseAgentStreamOptions = {}): void {
-	const { enabled = true } = options;
+export function initializeAgentStreamListener(): void {
+	if (_initialized) return;
+	_initialized = true;
 
-	// Get store actions (stable references)
-	const handleAgentChunk = useAgentStore((state) => state.handleAgentChunk);
-	const handleAgentToolStart = useAgentStore((state) => state.handleAgentToolStart);
-	const handleAgentToolEnd = useAgentStore((state) => state.handleAgentToolEnd);
-	const handleAgentComplete = useAgentStore((state) => state.handleAgentComplete);
-	const handleAgentError = useAgentStore((state) => state.handleAgentError);
-
-	// Track cleanup function
-	const cleanupRef = useRef<(() => void) | null>(null);
-
-	useEffect(() => {
-		if (!enabled) {
-			// Cleanup existing listener if disabled
-			if (cleanupRef.current) {
-				cleanupRef.current();
-				cleanupRef.current = null;
-			}
-			return;
-		}
-
-		const handlers: AgentEventHandlers = {
-			onChunk: handleAgentChunk,
-			onToolStart: handleAgentToolStart,
-			onToolEnd: handleAgentToolEnd,
-			onComplete: handleAgentComplete,
-			onError: handleAgentError,
-		};
-
-		// Start listening
-		listenToAgentEvents(handlers)
-			.then((unlisten) => {
-				cleanupRef.current = unlisten;
-			})
-			.catch((error) => {
-				console.error('Failed to listen to agent events:', error);
-			});
-
-		// Cleanup on unmount
-		return () => {
-			if (cleanupRef.current) {
-				cleanupRef.current();
-				cleanupRef.current = null;
-			}
-		};
-	}, [
-		enabled,
-		handleAgentChunk,
-		handleAgentToolStart,
-		handleAgentToolEnd,
-		handleAgentComplete,
-		handleAgentError,
-	]);
-}
-
-/**
- * Hook that provides both session management and stream listening
- *
- * Combines useAgentSession and useAgentStream for convenience.
- */
-export function useAgentSessionWithStream() {
-	// Enable stream listening
-	useAgentStream({ enabled: true });
-
-	// Return session state
-	const activeSessionId = useAgentStore((state) => state.activeSessionId);
-	const sessions = useAgentStore((state) => state.sessions);
-	const messages = useAgentStore((state) =>
-		activeSessionId ? state.messages.get(activeSessionId) || [] : []
-	);
-	const isRunning = useAgentStore((state) => state.isAgentRunning);
-	const error = useAgentStore((state) => state.error);
-
-	const createSession = useAgentStore((state) => state.createSession);
-	const sendMessage = useAgentStore((state) => state.sendMessage);
-	const clearError = useAgentStore((state) => state.clearError);
-
-	return {
-		sessionId: activeSessionId,
-		session: activeSessionId ? sessions.get(activeSessionId) : null,
-		messages,
-		isRunning,
-		error,
-		createSession,
-		sendMessage,
-		clearError,
+	const handlers: AgentEventHandlers = {
+		onChunk: (conversationId, content) => {
+			useAgentStore.getState().handleAgentChunk(conversationId, content);
+		},
+		onToolStart: (conversationId, toolCall) => {
+			useAgentStore.getState().handleAgentToolStart(conversationId, toolCall);
+		},
+		onToolEnd: (conversationId, toolCallId, result) => {
+			useAgentStore.getState().handleAgentToolEnd(conversationId, toolCallId, result);
+		},
+		onComplete: (conversationId, message) => {
+			useAgentStore.getState().handleAgentComplete(conversationId, message);
+		},
+		onError: (conversationId, error) => {
+			useAgentStore.getState().handleAgentError(conversationId, error);
+		},
 	};
+
+	listenToAgentEvents(handlers)
+		.then((unlisten) => {
+			_cleanup = unlisten;
+		})
+		.catch((error) => {
+			console.error('Failed to initialize agent stream listener:', error);
+			_initialized = false;
+		});
+}
+
+/**
+ * Teardown the singleton agent stream listener.
+ */
+export function teardownAgentStreamListener(): void {
+	if (_cleanup) {
+		_cleanup();
+		_cleanup = null;
+	}
+	_initialized = false;
 }

--- a/apps/desktop/src/stores/agentStore.ts
+++ b/apps/desktop/src/stores/agentStore.ts
@@ -53,6 +53,40 @@ export interface AgentSession {
 	model: string;
 }
 
+export interface SessionStreamState {
+	streamingMessageId: string | null;
+	streamingContent: string;
+	activeToolCalls: Map<string, ToolCallState>;
+	isStreaming: boolean;
+	error: string | null;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function createDefaultStreamState(): SessionStreamState {
+	return {
+		streamingMessageId: null,
+		streamingContent: '',
+		activeToolCalls: new Map(),
+		isStreaming: false,
+		error: null,
+	};
+}
+
+function getOrCreateStreamState(
+	map: Map<string, SessionStreamState>,
+	sessionId: string
+): SessionStreamState {
+	let state = map.get(sessionId);
+	if (!state) {
+		state = createDefaultStreamState();
+		map.set(sessionId, state);
+	}
+	return state;
+}
+
 // =============================================================================
 // State
 // =============================================================================
@@ -65,14 +99,8 @@ interface AgentState {
 	// Messages per session (sessionId -> messages)
 	messages: Map<string, Message[]>;
 
-	// Streaming state
-	streamingMessageId: string | null;
-	streamingContent: string;
-	activeToolCalls: Map<string, ToolCallState>;
-
-	// UI state
-	isAgentRunning: boolean;
-	error: string | null;
+	// Per-session streaming state
+	sessionStreaming: Map<string, SessionStreamState>;
 }
 
 interface AgentActions {
@@ -82,7 +110,7 @@ interface AgentActions {
 	deleteSession: (sessionId: string) => void;
 
 	// Message handling
-	sendMessage: (content: string, mode: MessageMode) => Promise<void>;
+	sendMessage: (sessionId: string, content: string, mode: MessageMode) => Promise<void>;
 	addUserMessage: (sessionId: string, content: string, mode: MessageMode) => string;
 
 	// Streaming handlers (called from event listener)
@@ -97,7 +125,7 @@ interface AgentActions {
 	persistSessions: () => void;
 
 	// Utilities
-	clearError: () => void;
+	clearError: (sessionId: string) => void;
 	getSessionMessages: (sessionId: string) => Message[];
 }
 
@@ -111,11 +139,7 @@ const initialState: AgentState = {
 	sessions: new Map(),
 	activeSessionId: null,
 	messages: new Map(),
-	streamingMessageId: null,
-	streamingContent: '',
-	activeToolCalls: new Map(),
-	isAgentRunning: false,
-	error: null,
+	sessionStreaming: new Map(),
 };
 
 // Create debounced save function (saves 1 second after last change)
@@ -135,6 +159,12 @@ export const useAgentStore = create<AgentStore>()(
 				set((state) => {
 					state.sessions = persisted.sessions;
 					state.messages = persisted.messages;
+					// Initialize empty streaming state for each loaded session
+					for (const sessionId of persisted.sessions.keys()) {
+						if (!state.sessionStreaming.has(sessionId)) {
+							state.sessionStreaming.set(sessionId, createDefaultStreamState());
+						}
+					}
 				});
 			}
 		},
@@ -155,7 +185,7 @@ export const useAgentStore = create<AgentStore>()(
 						model: model || 'claude-sonnet-4-20250514',
 					});
 					state.messages.set(sessionId, []);
-					state.activeSessionId = sessionId;
+					state.sessionStreaming.set(sessionId, createDefaultStreamState());
 				});
 
 				// Persist after creating session
@@ -164,9 +194,7 @@ export const useAgentStore = create<AgentStore>()(
 				return sessionId;
 			} catch (error) {
 				const errorMsg = error instanceof Error ? error.message : String(error);
-				set((state) => {
-					state.error = `Failed to create session: ${errorMsg}`;
-				});
+				console.error(`Failed to create session: ${errorMsg}`);
 				throw error;
 			}
 		},
@@ -183,8 +211,8 @@ export const useAgentStore = create<AgentStore>()(
 			set((state) => {
 				state.sessions.delete(sessionId);
 				state.messages.delete(sessionId);
+				state.sessionStreaming.delete(sessionId);
 				if (state.activeSessionId === sessionId) {
-					// Switch to another session or null
 					const remaining = Array.from(state.sessions.keys());
 					state.activeSessionId = remaining.length > 0 ? remaining[0] : null;
 				}
@@ -193,17 +221,12 @@ export const useAgentStore = create<AgentStore>()(
 			get().persistSessions();
 		},
 
-		sendMessage: async (content: string, mode: MessageMode) => {
-			console.log('[Store SEND] content:', content, 'mode:', mode);
-			const sessionId = get().activeSessionId;
+		sendMessage: async (sessionId: string, content: string, mode: MessageMode) => {
+			console.log('[Store SEND] sessionId:', sessionId, 'content:', content, 'mode:', mode);
 			if (!sessionId) {
-				console.error('[Store] No active session!');
-				set((state) => {
-					state.error = 'No active session';
-				});
+				console.error('[Store] No session ID provided!');
 				return;
 			}
-			console.log('[Store] Active sessionId:', sessionId);
 
 			// Add user message
 			get().addUserMessage(sessionId, content, mode);
@@ -222,9 +245,13 @@ export const useAgentStore = create<AgentStore>()(
 					isStreaming: true,
 				});
 				state.messages.set(sessionId, sessionMessages);
-				state.streamingMessageId = assistantMessageId;
-				state.streamingContent = '';
-				state.isAgentRunning = true;
+
+				// Update per-session streaming state
+				const streamState = getOrCreateStreamState(state.sessionStreaming, sessionId);
+				streamState.streamingMessageId = assistantMessageId;
+				streamState.streamingContent = '';
+				streamState.isStreaming = true;
+				streamState.error = null;
 			});
 
 			try {
@@ -240,9 +267,10 @@ export const useAgentStore = create<AgentStore>()(
 				const errorMsg = error instanceof Error ? error.message : String(error);
 				console.error('[Store] sendAgentMessage failed:', errorMsg);
 				set((state) => {
-					state.error = `Failed to send message: ${errorMsg}`;
-					state.isAgentRunning = false;
-					state.streamingMessageId = null;
+					const streamState = getOrCreateStreamState(state.sessionStreaming, sessionId);
+					streamState.error = `Failed to send message: ${errorMsg}`;
+					streamState.isStreaming = false;
+					streamState.streamingMessageId = null;
 				});
 			}
 		},
@@ -271,28 +299,30 @@ export const useAgentStore = create<AgentStore>()(
 		handleAgentChunk: (conversationId: string, content: string) => {
 			console.log('[Store CHUNK] conversationId:', conversationId, 'content:', content);
 			set((state) => {
-				state.streamingContent += content;
-				console.log('[Store] streamingContent now:', state.streamingContent.length, 'chars');
+				const streamState = getOrCreateStreamState(state.sessionStreaming, conversationId);
+				streamState.streamingContent += content;
+				console.log('[Store] streamingContent now:', streamState.streamingContent.length, 'chars');
 
 				// Update the streaming message
 				const messages = state.messages.get(conversationId);
-				if (messages && state.streamingMessageId) {
-					const msg = messages.find((m) => m.id === state.streamingMessageId);
+				if (messages && streamState.streamingMessageId) {
+					const msg = messages.find((m) => m.id === streamState.streamingMessageId);
 					if (msg) {
-						msg.content = state.streamingContent;
+						msg.content = streamState.streamingContent;
 						console.log('[Store] Updated message content');
 					} else {
-						console.warn('[Store] Could not find streaming message:', state.streamingMessageId);
+						console.warn('[Store] Could not find streaming message:', streamState.streamingMessageId);
 					}
 				} else {
-					console.warn('[Store] No messages for conversationId:', conversationId, 'or no streamingMessageId:', state.streamingMessageId);
+					console.warn('[Store] No messages for conversationId:', conversationId, 'or no streamingMessageId:', streamState.streamingMessageId);
 				}
 			});
 		},
 
 		handleAgentToolStart: (conversationId: string, toolCall: AgentToolCall) => {
 			set((state) => {
-				state.activeToolCalls.set(toolCall.id, {
+				const streamState = getOrCreateStreamState(state.sessionStreaming, conversationId);
+				streamState.activeToolCalls.set(toolCall.id, {
 					id: toolCall.id,
 					name: toolCall.name,
 					arguments: toolCall.arguments,
@@ -301,8 +331,8 @@ export const useAgentStore = create<AgentStore>()(
 
 				// Add tool call to streaming message
 				const messages = state.messages.get(conversationId);
-				if (messages && state.streamingMessageId) {
-					const msg = messages.find((m) => m.id === state.streamingMessageId);
+				if (messages && streamState.streamingMessageId) {
+					const msg = messages.find((m) => m.id === streamState.streamingMessageId);
 					if (msg) {
 						if (!msg.toolCalls) msg.toolCalls = [];
 						msg.toolCalls.push({
@@ -318,7 +348,8 @@ export const useAgentStore = create<AgentStore>()(
 
 		handleAgentToolEnd: (conversationId: string, toolCallId: string, result: string) => {
 			set((state) => {
-				const toolCall = state.activeToolCalls.get(toolCallId);
+				const streamState = getOrCreateStreamState(state.sessionStreaming, conversationId);
+				const toolCall = streamState.activeToolCalls.get(toolCallId);
 				if (toolCall) {
 					toolCall.status = 'completed';
 					toolCall.result = result;
@@ -326,8 +357,8 @@ export const useAgentStore = create<AgentStore>()(
 
 				// Update tool call in message
 				const messages = state.messages.get(conversationId);
-				if (messages && state.streamingMessageId) {
-					const msg = messages.find((m) => m.id === state.streamingMessageId);
+				if (messages && streamState.streamingMessageId) {
+					const msg = messages.find((m) => m.id === streamState.streamingMessageId);
 					if (msg?.toolCalls) {
 						const tc = msg.toolCalls.find((t) => t.id === toolCallId);
 						if (tc) {
@@ -342,10 +373,12 @@ export const useAgentStore = create<AgentStore>()(
 		handleAgentComplete: (conversationId: string, message: AgentMessage) => {
 			console.log('[Store COMPLETE] conversationId:', conversationId, 'message:', message);
 			set((state) => {
+				const streamState = getOrCreateStreamState(state.sessionStreaming, conversationId);
+
 				// Finalize the streaming message
 				const messages = state.messages.get(conversationId);
-				if (messages && state.streamingMessageId) {
-					const msg = messages.find((m) => m.id === state.streamingMessageId);
+				if (messages && streamState.streamingMessageId) {
+					const msg = messages.find((m) => m.id === streamState.streamingMessageId);
 					if (msg) {
 						console.log('[Store] Finalizing message, content length:', message.content.length);
 						msg.content = message.content;
@@ -356,17 +389,17 @@ export const useAgentStore = create<AgentStore>()(
 								name: tc.name,
 								arguments: tc.arguments,
 								status: 'completed' as const,
-								result: state.activeToolCalls.get(tc.id)?.result,
+								result: streamState.activeToolCalls.get(tc.id)?.result,
 							}));
 						}
 					}
 				}
 
-				// Reset streaming state
-				state.streamingMessageId = null;
-				state.streamingContent = '';
-				state.activeToolCalls = new Map();
-				state.isAgentRunning = false;
+				// Reset per-session streaming state
+				streamState.streamingMessageId = null;
+				streamState.streamingContent = '';
+				streamState.activeToolCalls = new Map();
+				streamState.isStreaming = false;
 			});
 
 			// Persist after message completion
@@ -376,27 +409,32 @@ export const useAgentStore = create<AgentStore>()(
 		handleAgentError: (conversationId: string, error: string) => {
 			console.error('[Store ERROR] conversationId:', conversationId, 'error:', error);
 			set((state) => {
-				state.error = error;
-				state.isAgentRunning = false;
-				state.streamingMessageId = null;
-				state.streamingContent = '';
-				state.activeToolCalls = new Map();
+				const streamState = getOrCreateStreamState(state.sessionStreaming, conversationId);
+				streamState.error = error;
+				streamState.isStreaming = false;
 
 				// Mark streaming message as error
 				const messages = state.messages.get(conversationId);
-				if (messages && state.streamingMessageId) {
-					const msg = messages.find((m) => m.id === state.streamingMessageId);
+				if (messages && streamState.streamingMessageId) {
+					const msg = messages.find((m) => m.id === streamState.streamingMessageId);
 					if (msg) {
 						msg.isStreaming = false;
 						msg.content = `Error: ${error}`;
 					}
 				}
+
+				streamState.streamingMessageId = null;
+				streamState.streamingContent = '';
+				streamState.activeToolCalls = new Map();
 			});
 		},
 
-		clearError: () => {
+		clearError: (sessionId: string) => {
 			set((state) => {
-				state.error = null;
+				const streamState = state.sessionStreaming.get(sessionId);
+				if (streamState) {
+					streamState.error = null;
+				}
 			});
 		},
 
@@ -409,9 +447,6 @@ export const useAgentStore = create<AgentStore>()(
 // =============================================================================
 // Selector Hooks (with stable references for React 19 compatibility)
 // =============================================================================
-
-// To avoid infinite loops in React 19's useSyncExternalStore, we use stable
-// references and memoize results at the store level instead of in selectors.
 
 export const useActiveSession = (): AgentSession | null => {
 	const activeSessionId = useAgentStore((state) => state.activeSessionId);
@@ -437,12 +472,43 @@ export const useActiveSessionMessages = (): Message[] => {
 	return messages.get(activeSessionId) ?? EMPTY_MESSAGES;
 };
 
+// Per-session streaming selectors
+export const useSessionStreamState = (sessionId: string | null): SessionStreamState | null => {
+	return useAgentStore((state) => {
+		if (!sessionId) return null;
+		return state.sessionStreaming.get(sessionId) ?? null;
+	});
+};
+
+export const useIsSessionStreaming = (sessionId: string | null): boolean => {
+	return useAgentStore((state) => {
+		if (!sessionId) return false;
+		return state.sessionStreaming.get(sessionId)?.isStreaming ?? false;
+	});
+};
+
+export const useSessionError = (sessionId: string | null): string | null => {
+	return useAgentStore((state) => {
+		if (!sessionId) return null;
+		return state.sessionStreaming.get(sessionId)?.error ?? null;
+	});
+};
+
+// Legacy selectors — kept for backward compatibility but delegate to per-session state
 export const useIsAgentRunning = (): boolean => {
-	return useAgentStore((state) => state.isAgentRunning);
+	return useAgentStore((state) => {
+		for (const streamState of state.sessionStreaming.values()) {
+			if (streamState.isStreaming) return true;
+		}
+		return false;
+	});
 };
 
 export const useAgentError = (): string | null => {
-	return useAgentStore((state) => state.error);
+	return useAgentStore((state) => {
+		if (!state.activeSessionId) return null;
+		return state.sessionStreaming.get(state.activeSessionId)?.error ?? null;
+	});
 };
 
 export const useSessions = (): AgentSession[] => {


### PR DESCRIPTION
Each agent tab now maintains its own isolated chat session instead of all tabs sharing a single global session. This enables independent concurrent streaming across multiple tabs.

Changes:
- Replace global streaming state with per-session SessionStreamState map
- sendMessage now accepts explicit sessionId parameter
- Convert useAgentStream hook to singleton initializeAgentStreamListener()
- Rewrite useAgentSession hook to accept sessionId from tab data
- Wire AgentWindow to use its tab-specific session via initialSessionId
- Derive activeSessionId from focused tab in AgentPanel
- Deduplicate sidebar: clicking existing session activates its tab
- Add pulsing dot streaming indicator on tabs and sidebar sessions
- Show primary-colored icon for sessions with open tabs
- Fix React 19 useSyncExternalStore infinite loop with useRef caching