### PR TITLE
Enable clippy pedantic and rustfmt across all crates

### DIFF
--- a/apps/desktop/src-tauri/src/agent_commands.rs
+++ b/apps/desktop/src-tauri/src/agent_commands.rs
@@ -4,20 +4,20 @@
 //! through the Solo server via WebSocket — the desktop app manages sessions,
 //! credentials (keychain), and tool execution for server-delegated tools.
 
+use crate::fs_commands::FsState;
+use futures_util::{SinkExt, StreamExt};
 use solo_agent::{
+    keychain,
     models::{get_all_models, get_models_for_provider},
     AgentManager, ProviderType,
-    keychain,
 };
 use solo_protocol::{AgentMessage, AgentToolCall, BackendEvent, ContentBlock, ToolResult};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Manager, State};
 use tokio::sync::{watch, RwLock};
-use tracing::{debug, error, info, warn};
-use futures_util::{SinkExt, StreamExt};
 use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
-use crate::fs_commands::FsState;
+use tracing::{debug, error, info, warn};
 
 // =============================================================================
 // State
@@ -30,7 +30,8 @@ pub struct AgentState {
     /// Abort senders per session — send `true` to cancel a running stream
     abort_senders: Arc<RwLock<HashMap<String, watch::Sender<bool>>>>,
     /// Approval channels per session — frontend sends (tool_call_id, approved) tuples
-    approval_channels: Arc<RwLock<HashMap<String, tokio::sync::mpsc::UnboundedSender<(String, bool)>>>>,
+    approval_channels:
+        Arc<RwLock<HashMap<String, tokio::sync::mpsc::UnboundedSender<(String, bool)>>>>,
 }
 
 impl AgentState {
@@ -92,14 +93,16 @@ pub struct ToolDefinitionResponse {
 #[tauri::command]
 pub async fn get_providers() -> Result<Vec<String>, String> {
     debug!("Getting available providers");
-    Ok(vec!["anthropic".to_string(), "openai".to_string(), "gemini".to_string()])
+    Ok(vec![
+        "anthropic".to_string(),
+        "openai".to_string(),
+        "gemini".to_string(),
+    ])
 }
 
 /// Get the currently active provider
 #[tauri::command]
-pub async fn get_active_provider(
-    state: State<'_, AgentState>,
-) -> Result<String, String> {
+pub async fn get_active_provider(state: State<'_, AgentState>) -> Result<String, String> {
     debug!("Getting active provider");
     let provider = state.manager.get_active_provider().await;
     Ok(provider.as_str().to_string())
@@ -270,7 +273,8 @@ pub async fn agent_create_session(
 
     info!(session_id = %session_id, model = ?model, "Creating agent session");
 
-    state.manager
+    state
+        .manager
         .create_session(session_id.clone(), model)
         .await
         .map_err(|e| e.to_string())?;
@@ -286,7 +290,8 @@ pub async fn agent_update_session_model(
     state: State<'_, AgentState>,
 ) -> Result<(), String> {
     info!(session_id = %session_id, model = %model, "Updating session model");
-    state.manager
+    state
+        .manager
         .update_session_model(&session_id, model)
         .await
         .map_err(|e| e.to_string())
@@ -324,29 +329,38 @@ pub async fn agent_send_message_server(
 
     // Read workspace root
     let fs_state = app.state::<FsState>();
-    let workspace_root = fs_state.workspace_root.read().await.clone()
+    let workspace_root = fs_state
+        .workspace_root
+        .read()
+        .await
+        .clone()
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_default();
 
     // Build chat history from the session
-    let chat_history: Vec<serde_json::Value> = if let Some(sessions) = state.manager.get_session(&session_id).await {
-        if let Some(session) = sessions.get(&session_id) {
-            session.history().iter().map(|msg| {
-                serde_json::json!({
-                    "role": msg.role,
-                    "content": msg.display_text()
-                })
-            }).collect()
+    let chat_history: Vec<serde_json::Value> =
+        if let Some(sessions) = state.manager.get_session(&session_id).await {
+            if let Some(session) = sessions.get(&session_id) {
+                session
+                    .history()
+                    .iter()
+                    .map(|msg| {
+                        serde_json::json!({
+                            "role": msg.role,
+                            "content": msg.display_text()
+                        })
+                    })
+                    .collect()
+            } else {
+                vec![]
+            }
         } else {
             vec![]
-        }
-    } else {
-        vec![]
-    };
+        };
 
     // Build the server URL
-    let server_url = std::env::var("SOLO_SERVER_URL")
-        .unwrap_or_else(|_| DEFAULT_SERVER_URL.to_string());
+    let server_url =
+        std::env::var("SOLO_SERVER_URL").unwrap_or_else(|_| DEFAULT_SERVER_URL.to_string());
     let ws_url = format!("{}/agent/ws/agent", server_url);
 
     info!(session_id = %session_id, ws_url = %ws_url, "Connecting to Solo server");
@@ -825,7 +839,8 @@ pub async fn agent_get_history(
 ) -> Result<Vec<AgentMessage>, String> {
     debug!(session_id = %session_id, "Getting conversation history");
 
-    let sessions = state.manager
+    let sessions = state
+        .manager
         .get_session(&session_id)
         .await
         .ok_or_else(|| format!("Session not found: {}", session_id))?;

--- a/apps/desktop/src-tauri/src/auth_commands.rs
+++ b/apps/desktop/src-tauri/src/auth_commands.rs
@@ -276,15 +276,15 @@ pub async fn auth_start_magic_link(
         info!("Magic link sent successfully");
         Ok(())
     } else {
-        let error: SupabaseError = response
-            .json()
-            .await
-            .unwrap_or(SupabaseError {
-                error: Some("Unknown error".to_string()),
-                error_description: None,
-                message: None,
-            });
-        Err(error.message.or(error.error_description).or(error.error)
+        let error: SupabaseError = response.json().await.unwrap_or(SupabaseError {
+            error: Some("Unknown error".to_string()),
+            error_description: None,
+            message: None,
+        });
+        Err(error
+            .message
+            .or(error.error_description)
+            .or(error.error)
             .unwrap_or_else(|| "Failed to send magic link".to_string()))
     }
 }
@@ -295,7 +295,10 @@ pub async fn auth_exchange_code(
     code: String,
     state: State<'_, AuthState>,
 ) -> Result<AuthStateResponse, String> {
-    info!("Exchanging authorization code for tokens, code={}", &code[..8]);
+    info!(
+        "Exchanging authorization code for tokens, code={}",
+        &code[..8]
+    );
 
     // Get PKCE verifier
     let pkce = match state.pkce.read().await.clone() {
@@ -369,17 +372,19 @@ pub async fn auth_exchange_code(
         let body = response.text().await.unwrap_or_default();
         warn!("Token exchange failed with status {}: {}", status, body);
 
-        let error: SupabaseError = serde_json::from_str(&body)
-            .unwrap_or(SupabaseError {
-                error: Some(format!("HTTP {}", status)),
-                error_description: Some(body),
-                message: None,
-            });
+        let error: SupabaseError = serde_json::from_str(&body).unwrap_or(SupabaseError {
+            error: Some(format!("HTTP {}", status)),
+            error_description: Some(body),
+            message: None,
+        });
 
         // Clear PKCE state on error
         *state.pkce.write().await = None;
 
-        let error_msg = error.message.or(error.error_description).or(error.error)
+        let error_msg = error
+            .message
+            .or(error.error_description)
+            .or(error.error)
             .unwrap_or_else(|| "Failed to exchange code".to_string());
         warn!("Auth error: {}", error_msg);
         Err(error_msg)
@@ -388,9 +393,7 @@ pub async fn auth_exchange_code(
 
 /// Get current session (restores from keychain if needed)
 #[tauri::command]
-pub async fn auth_get_session(
-    state: State<'_, AuthState>,
-) -> Result<AuthStateResponse, String> {
+pub async fn auth_get_session(state: State<'_, AuthState>) -> Result<AuthStateResponse, String> {
     debug!("Getting current session");
 
     // Check cached session first
@@ -477,8 +480,8 @@ pub async fn auth_refresh_session(
 ) -> Result<AuthStateResponse, String> {
     info!("Refreshing session");
 
-    let refresh_token = keychain_read(KEYCHAIN_REFRESH_TOKEN)
-        .ok_or("No refresh token available")?;
+    let refresh_token =
+        keychain_read(KEYCHAIN_REFRESH_TOKEN).ok_or("No refresh token available")?;
 
     refresh_session_internal(&state, &refresh_token).await
 }
@@ -538,9 +541,7 @@ async fn refresh_session_internal(
 
 /// Sign out - clear session and tokens
 #[tauri::command]
-pub async fn auth_sign_out(
-    state: State<'_, AuthState>,
-) -> Result<(), String> {
+pub async fn auth_sign_out(state: State<'_, AuthState>) -> Result<(), String> {
     info!("Signing out");
 
     // Try to call Supabase logout (best effort)
@@ -567,9 +568,7 @@ pub async fn auth_sign_out(
 
 /// Get the current access token (for API calls)
 #[tauri::command]
-pub async fn auth_get_access_token(
-    state: State<'_, AuthState>,
-) -> Result<Option<String>, String> {
+pub async fn auth_get_access_token(state: State<'_, AuthState>) -> Result<Option<String>, String> {
     if let Some(session) = state.session.read().await.as_ref() {
         return Ok(Some(session.access_token.clone()));
     }

--- a/apps/desktop/src-tauri/src/embedding_commands.rs
+++ b/apps/desktop/src-tauri/src/embedding_commands.rs
@@ -9,7 +9,7 @@ use solo_embeddings::{
 use std::sync::Arc;
 use tauri::State;
 use tokio::sync::RwLock;
-use tracing::{debug, info, error};
+use tracing::{debug, error, info};
 
 // =============================================================================
 // State
@@ -92,9 +92,9 @@ pub async fn embedding_index_code(
     state: State<'_, EmbeddingState>,
 ) -> Result<usize, String> {
     let mut index = state.code_index.write().await;
-    let index = index
-        .as_mut()
-        .ok_or_else(|| "Embedding provider not initialized. Call embedding_init first.".to_string())?;
+    let index = index.as_mut().ok_or_else(|| {
+        "Embedding provider not initialized. Call embedding_init first.".to_string()
+    })?;
 
     debug!(count = chunks.len(), "Indexing code chunks");
 
@@ -116,10 +116,7 @@ pub async fn embedding_index_code(
 
     let count = items.len();
 
-    index
-        .add_many(items)
-        .await
-        .map_err(|e| e.to_string())?;
+    index.add_many(items).await.map_err(|e| e.to_string())?;
 
     info!(count = count, total = index.len(), "Code chunks indexed");
     Ok(index.len())
@@ -133,9 +130,9 @@ pub async fn embedding_search_code(
     state: State<'_, EmbeddingState>,
 ) -> Result<Vec<CodeSearchResultResponse>, String> {
     let index = state.code_index.read().await;
-    let index = index
-        .as_ref()
-        .ok_or_else(|| "Embedding provider not initialized. Call embedding_init first.".to_string())?;
+    let index = index.as_ref().ok_or_else(|| {
+        "Embedding provider not initialized. Call embedding_init first.".to_string()
+    })?;
 
     let limit = limit.unwrap_or(10);
     debug!(query = %query, limit = limit, "Searching code");
@@ -168,16 +165,13 @@ pub async fn embedding_embed_text(
     state: State<'_, EmbeddingState>,
 ) -> Result<Vec<f32>, String> {
     let provider = state.provider.read().await;
-    let provider = provider
-        .as_ref()
-        .ok_or_else(|| "Embedding provider not initialized. Call embedding_init first.".to_string())?;
+    let provider = provider.as_ref().ok_or_else(|| {
+        "Embedding provider not initialized. Call embedding_init first.".to_string()
+    })?;
 
     debug!(text_len = text.len(), "Generating embedding");
 
-    let embedding = provider
-        .embed(&text)
-        .await
-        .map_err(|e| e.to_string())?;
+    let embedding = provider.embed(&text).await.map_err(|e| e.to_string())?;
 
     info!(dimensions = embedding.dimensions, "Embedding generated");
     Ok(embedding.values)
@@ -185,9 +179,7 @@ pub async fn embedding_embed_text(
 
 /// Clear the code index
 #[tauri::command]
-pub async fn embedding_clear_index(
-    state: State<'_, EmbeddingState>,
-) -> Result<(), String> {
+pub async fn embedding_clear_index(state: State<'_, EmbeddingState>) -> Result<(), String> {
     let mut index = state.code_index.write().await;
     if let Some(index) = index.as_mut() {
         index.clear();

--- a/apps/desktop/src-tauri/src/fs_commands.rs
+++ b/apps/desktop/src-tauri/src/fs_commands.rs
@@ -3,7 +3,8 @@
 //! This module contains all file system related IPC commands.
 
 use solo_fs::{
-    operations, tree, watcher::{FileEventType, FileWatcher},
+    operations, tree,
+    watcher::{FileEventType, FileWatcher},
 };
 use solo_protocol::{
     BackendEvent, DirectoryReadRequest, DirectoryReadResponse, FileCreateRequest,
@@ -85,9 +86,7 @@ pub async fn open_folder_dialog(app: AppHandle) -> Result<Option<String>, String
             debug!("Folder dialog cancelled");
             Ok(None)
         }
-        Err(_) => {
-            Err("Dialog was cancelled".to_string())
-        }
+        Err(_) => Err("Dialog was cancelled".to_string()),
     }
 }
 
@@ -147,10 +146,7 @@ pub async fn read_directory(
     // Count total entries for progress indication
     let total_count = tree::count_entries(&path).unwrap_or(0);
 
-    Ok(DirectoryReadResponse {
-        entry,
-        total_count,
-    })
+    Ok(DirectoryReadResponse { entry, total_count })
 }
 
 /// Create a new file
@@ -216,11 +212,13 @@ pub async fn read_file(
         path: request.path.clone(),
     })?;
 
-    let workspace_canonical = workspace_path.canonicalize().map_err(|e| FileOperationError {
-        code: FileErrorCode::IoError,
-        message: e.to_string(),
-        path: request.path.clone(),
-    })?;
+    let workspace_canonical = workspace_path
+        .canonicalize()
+        .map_err(|e| FileOperationError {
+            code: FileErrorCode::IoError,
+            message: e.to_string(),
+            path: request.path.clone(),
+        })?;
 
     if !canonical.starts_with(&workspace_canonical) {
         return Err(FileOperationError {
@@ -270,11 +268,13 @@ pub async fn write_file(
         path: request.path.clone(),
     })?;
 
-    let workspace_canonical = workspace_path.canonicalize().map_err(|e| FileOperationError {
-        code: FileErrorCode::IoError,
-        message: e.to_string(),
-        path: request.path.clone(),
-    })?;
+    let workspace_canonical = workspace_path
+        .canonicalize()
+        .map_err(|e| FileOperationError {
+            code: FileErrorCode::IoError,
+            message: e.to_string(),
+            path: request.path.clone(),
+        })?;
 
     if !canonical.starts_with(&workspace_canonical) {
         return Err(FileOperationError {
@@ -386,7 +386,10 @@ pub async fn start_watching(
 
     // Start watching FIRST - if this fails, we don't spawn the event task
     let path_buf = PathBuf::from(&path);
-    watcher.watch(&path_buf, recursive).await.map_err(|e| e.to_string())?;
+    watcher
+        .watch(&path_buf, recursive)
+        .await
+        .map_err(|e| e.to_string())?;
 
     // Only spawn the event forwarder task for new watchers, after watch succeeds
     if is_new_watcher {

--- a/apps/desktop/src-tauri/src/git_commands.rs
+++ b/apps/desktop/src-tauri/src/git_commands.rs
@@ -5,12 +5,12 @@
 //! because `git2::Repository` is `!Send`.
 
 use git2::{
-	Cred, Delta, DiffOptions, FetchOptions, IndexAddOption, PushOptions, RemoteCallbacks,
-	Repository, ResetType, Signature, StatusOptions,
+    Cred, Delta, DiffOptions, FetchOptions, IndexAddOption, PushOptions, RemoteCallbacks,
+    Repository, ResetType, Signature, StatusOptions,
 };
 use solo_protocol::{
-	BackendEvent, GitChangedFile, GitChangesResponse, GitChangesSummary, GitFileDiffResponse,
-	GitFileStatus, GitPullResponse, GitPushResponse, GitRepoStatus,
+    BackendEvent, GitChangedFile, GitChangesResponse, GitChangesSummary, GitFileDiffResponse,
+    GitFileStatus, GitPullResponse, GitPushResponse, GitRepoStatus,
 };
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -20,151 +20,145 @@ use tracing::{info, warn};
 
 /// Application state for git operations
 pub struct GitState {
-	/// Cached workspace path
-	pub workspace_path: RwLock<Option<PathBuf>>,
+    /// Cached workspace path
+    pub workspace_path: RwLock<Option<PathBuf>>,
 }
 
 impl GitState {
-	pub fn new() -> Self {
-		Self {
-			workspace_path: RwLock::new(None),
-		}
-	}
+    pub fn new() -> Self {
+        Self {
+            workspace_path: RwLock::new(None),
+        }
+    }
 }
 
 impl Default for GitState {
-	fn default() -> Self {
-		Self::new()
-	}
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 /// Helper to get the workspace path from FsState
 async fn get_workspace_path(
-	fs_state: &State<'_, crate::fs_commands::FsState>,
+    fs_state: &State<'_, crate::fs_commands::FsState>,
 ) -> Result<PathBuf, String> {
-	let guard = fs_state.workspace_root.read().await;
-	guard
-		.clone()
-		.ok_or_else(|| "No workspace folder open".to_string())
+    let guard = fs_state.workspace_root.read().await;
+    guard
+        .clone()
+        .ok_or_else(|| "No workspace folder open".to_string())
 }
 
 /// Emit a git progress event
 fn emit_git_progress(app: &AppHandle, operation: &str, message: &str) {
-	let _ = app.emit(
-		"backend-event",
-		&BackendEvent::GitProgress {
-			operation: operation.to_string(),
-			message: message.to_string(),
-		},
-	);
+    let _ = app.emit(
+        "backend-event",
+        &BackendEvent::GitProgress {
+            operation: operation.to_string(),
+            message: message.to_string(),
+        },
+    );
 }
 
 /// Emit a git changes updated event
 fn emit_git_changes_updated(app: &AppHandle) {
-	let _ = app.emit(
-		"backend-event",
-		&BackendEvent::GitChangesUpdated {},
-	);
+    let _ = app.emit("backend-event", &BackendEvent::GitChangesUpdated {});
 }
 
 /// Clean up stale git lock files (older than 5 minutes)
 fn cleanup_git_locks(project_path: &Path) {
-	let lock_files = [
-		project_path.join(".git/index.lock"),
-		project_path.join(".git/HEAD.lock"),
-		project_path.join(".git/config.lock"),
-	];
+    let lock_files = [
+        project_path.join(".git/index.lock"),
+        project_path.join(".git/HEAD.lock"),
+        project_path.join(".git/config.lock"),
+    ];
 
-	for lock_file in &lock_files {
-		if lock_file.exists() {
-			if let Ok(metadata) = std::fs::metadata(lock_file) {
-				if let Ok(modified) = metadata.modified() {
-					let age = std::time::SystemTime::now()
-						.duration_since(modified)
-						.unwrap_or_default();
-					if age > std::time::Duration::from_secs(300) {
-						if let Err(e) = std::fs::remove_file(lock_file) {
-							warn!("Could not clean up lock file {:?}: {}", lock_file, e);
-						} else {
-							info!("Cleaned up stale lock file: {:?}", lock_file);
-						}
-					}
-				}
-			}
-		}
-	}
+    for lock_file in &lock_files {
+        if lock_file.exists() {
+            if let Ok(metadata) = std::fs::metadata(lock_file) {
+                if let Ok(modified) = metadata.modified() {
+                    let age = std::time::SystemTime::now()
+                        .duration_since(modified)
+                        .unwrap_or_default();
+                    if age > std::time::Duration::from_secs(300) {
+                        if let Err(e) = std::fs::remove_file(lock_file) {
+                            warn!("Could not clean up lock file {:?}: {}", lock_file, e);
+                        } else {
+                            info!("Cleaned up stale lock file: {:?}", lock_file);
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Ensure the repo is initialized and scoped to the project path
 fn ensure_local_repo_scope(project_path: &Path) -> Result<Repository, String> {
-	let git_dir = project_path.join(".git");
+    let git_dir = project_path.join(".git");
 
-	// Check if there's a repo at this exact path
-	if git_dir.exists() {
-		if let Ok(repo) = Repository::open(project_path) {
-			// Verify it's scoped to our project
-			if let Some(workdir) = repo.workdir() {
-				if workdir == project_path {
-					return Ok(repo);
-				}
-			}
-		}
-	}
+    // Check if there's a repo at this exact path
+    if git_dir.exists() {
+        if let Ok(repo) = Repository::open(project_path) {
+            // Verify it's scoped to our project
+            if let Some(workdir) = repo.workdir() {
+                if workdir == project_path {
+                    return Ok(repo);
+                }
+            }
+        }
+    }
 
-	// Initialize a new repo
-	Repository::init(project_path).map_err(|e| format!("Failed to init git repo: {}", e))
+    // Initialize a new repo
+    Repository::init(project_path).map_err(|e| format!("Failed to init git repo: {}", e))
 }
 
 /// Upsert a remote — set URL if exists, or add new
 fn upsert_remote(repo: &Repository, name: &str, url: &str) -> Result<(), String> {
-	if repo.find_remote(name).is_ok() {
-		repo.remote_set_url(name, url)
-			.map_err(|e| format!("Failed to set remote URL: {}", e))?;
-	} else {
-		repo.remote(name, url)
-			.map_err(|e| format!("Failed to add remote: {}", e))?;
-	}
-	Ok(())
+    if repo.find_remote(name).is_ok() {
+        repo.remote_set_url(name, url)
+            .map_err(|e| format!("Failed to set remote URL: {}", e))?;
+    } else {
+        repo.remote(name, url)
+            .map_err(|e| format!("Failed to add remote: {}", e))?;
+    }
+    Ok(())
 }
 
 /// Check info about the github-integ remote
-fn get_github_integ_info(
-	repo: &Repository,
-	branch: &str,
-) -> (bool, bool) {
-	let has_remote = repo.find_remote("github-integ").is_ok();
-	if !has_remote {
-		return (false, false);
-	}
+fn get_github_integ_info(repo: &Repository, branch: &str) -> (bool, bool) {
+    let has_remote = repo.find_remote("github-integ").is_ok();
+    if !has_remote {
+        return (false, false);
+    }
 
-	let ref_name = format!("refs/remotes/github-integ/{}", branch);
-	let has_branch = repo.refname_to_id(&ref_name).is_ok();
+    let ref_name = format!("refs/remotes/github-integ/{}", branch);
+    let has_branch = repo.refname_to_id(&ref_name).is_ok();
 
-	(has_remote, has_branch)
+    (has_remote, has_branch)
 }
 
 /// Create auth callbacks with token
 fn make_fetch_options<'a>(token: &'a str) -> FetchOptions<'a> {
-	let mut callbacks = RemoteCallbacks::new();
-	let token_owned = token.to_string();
-	callbacks.credentials(move |_url, _username, _allowed| {
-		Cred::userpass_plaintext("x-access-token", &token_owned)
-	});
-	let mut fetch_opts = FetchOptions::new();
-	fetch_opts.remote_callbacks(callbacks);
-	fetch_opts
+    let mut callbacks = RemoteCallbacks::new();
+    let token_owned = token.to_string();
+    callbacks.credentials(move |_url, _username, _allowed| {
+        Cred::userpass_plaintext("x-access-token", &token_owned)
+    });
+    let mut fetch_opts = FetchOptions::new();
+    fetch_opts.remote_callbacks(callbacks);
+    fetch_opts
 }
 
 /// Create push options with token auth
 fn make_push_options<'a>(token: &'a str) -> PushOptions<'a> {
-	let mut callbacks = RemoteCallbacks::new();
-	let token_owned = token.to_string();
-	callbacks.credentials(move |_url, _username, _allowed| {
-		Cred::userpass_plaintext("x-access-token", &token_owned)
-	});
-	let mut push_opts = PushOptions::new();
-	push_opts.remote_callbacks(callbacks);
-	push_opts
+    let mut callbacks = RemoteCallbacks::new();
+    let token_owned = token.to_string();
+    callbacks.credentials(move |_url, _username, _allowed| {
+        Cred::userpass_plaintext("x-access-token", &token_owned)
+    });
+    let mut push_opts = PushOptions::new();
+    push_opts.remote_callbacks(callbacks);
+    push_opts
 }
 
 // =============================================================================
@@ -174,417 +168,424 @@ fn make_push_options<'a>(token: &'a str) -> PushOptions<'a> {
 /// Get the git repository status (is repo, branch, SHA, remote info)
 #[tauri::command]
 pub async fn git_get_status(
-	fs_state: State<'_, crate::fs_commands::FsState>,
+    fs_state: State<'_, crate::fs_commands::FsState>,
 ) -> Result<GitRepoStatus, String> {
-	let workspace_path = get_workspace_path(&fs_state).await?;
+    let workspace_path = get_workspace_path(&fs_state).await?;
 
-	tokio::task::spawn_blocking(move || {
-		let git_dir = workspace_path.join(".git");
-		if !git_dir.exists() {
-			return Ok(GitRepoStatus {
-				is_repo: false,
-				current_branch: None,
-				head_sha: None,
-				has_remote: false,
-				remote_url: None,
-				commits_ahead: None,
-			});
-		}
+    tokio::task::spawn_blocking(move || {
+        let git_dir = workspace_path.join(".git");
+        if !git_dir.exists() {
+            return Ok(GitRepoStatus {
+                is_repo: false,
+                current_branch: None,
+                head_sha: None,
+                has_remote: false,
+                remote_url: None,
+                commits_ahead: None,
+            });
+        }
 
-		let repo = Repository::open(&workspace_path)
-			.map_err(|e| format!("Failed to open repo: {}", e))?;
+        let repo =
+            Repository::open(&workspace_path).map_err(|e| format!("Failed to open repo: {}", e))?;
 
-		let current_branch = repo
-			.head()
-			.ok()
-			.and_then(|h| h.shorthand().map(String::from));
+        let current_branch = repo
+            .head()
+            .ok()
+            .and_then(|h| h.shorthand().map(String::from));
 
-		let head_sha = repo
-			.head()
-			.ok()
-			.and_then(|h| h.target())
-			.map(|oid| oid.to_string());
+        let head_sha = repo
+            .head()
+            .ok()
+            .and_then(|h| h.target())
+            .map(|oid| oid.to_string());
 
-		let (has_remote, remote_url) = match repo.find_remote("github-integ") {
-			Ok(remote) => (true, remote.url().map(String::from)),
-			Err(_) => match repo.find_remote("origin") {
-				Ok(remote) => (true, remote.url().map(String::from)),
-				Err(_) => (false, None),
-			},
-		};
+        let (has_remote, remote_url) = match repo.find_remote("github-integ") {
+            Ok(remote) => (true, remote.url().map(String::from)),
+            Err(_) => match repo.find_remote("origin") {
+                Ok(remote) => (true, remote.url().map(String::from)),
+                Err(_) => (false, None),
+            },
+        };
 
-		// Compute commits ahead of remote tracking branch
-		let commits_ahead = if has_remote {
-			if let Some(ref branch) = current_branch {
-				// Try github-integ remote first, then origin
-				let remote_ref = format!("refs/remotes/github-integ/{}", branch);
-				let remote_oid = repo.refname_to_id(&remote_ref).ok().or_else(|| {
-					let origin_ref = format!("refs/remotes/origin/{}", branch);
-					repo.refname_to_id(&origin_ref).ok()
-				});
+        // Compute commits ahead of remote tracking branch
+        let commits_ahead = if has_remote {
+            if let Some(ref branch) = current_branch {
+                // Try github-integ remote first, then origin
+                let remote_ref = format!("refs/remotes/github-integ/{}", branch);
+                let remote_oid = repo.refname_to_id(&remote_ref).ok().or_else(|| {
+                    let origin_ref = format!("refs/remotes/origin/{}", branch);
+                    repo.refname_to_id(&origin_ref).ok()
+                });
 
-				if let (Some(remote_oid), Ok(head_ref)) = (remote_oid, repo.head()) {
-					if let Some(head_oid) = head_ref.target() {
-						let mut count = 0u32;
-						if let Ok(mut revwalk) = repo.revwalk() {
-							let _ = revwalk.push(head_oid);
-							let _ = revwalk.hide(remote_oid);
-							count = revwalk.count() as u32;
-						}
-						Some(count)
-					} else {
-						Some(0)
-					}
-				} else if repo.head().is_ok() {
-					// Has remote but no tracking branch yet — all local commits are ahead
-					if let Ok(head_ref) = repo.head() {
-						if let Some(head_oid) = head_ref.target() {
-							let mut count = 0u32;
-							if let Ok(mut revwalk) = repo.revwalk() {
-								let _ = revwalk.push(head_oid);
-								count = revwalk.count() as u32;
-							}
-							Some(count)
-						} else {
-							Some(0)
-						}
-					} else {
-						Some(0)
-					}
-				} else {
-					Some(0)
-				}
-			} else {
-				None
-			}
-		} else {
-			None
-		};
+                if let (Some(remote_oid), Ok(head_ref)) = (remote_oid, repo.head()) {
+                    if let Some(head_oid) = head_ref.target() {
+                        let mut count = 0u32;
+                        if let Ok(mut revwalk) = repo.revwalk() {
+                            let _ = revwalk.push(head_oid);
+                            let _ = revwalk.hide(remote_oid);
+                            count = revwalk.count() as u32;
+                        }
+                        Some(count)
+                    } else {
+                        Some(0)
+                    }
+                } else if repo.head().is_ok() {
+                    // Has remote but no tracking branch yet — all local commits are ahead
+                    if let Ok(head_ref) = repo.head() {
+                        if let Some(head_oid) = head_ref.target() {
+                            let mut count = 0u32;
+                            if let Ok(mut revwalk) = repo.revwalk() {
+                                let _ = revwalk.push(head_oid);
+                                count = revwalk.count() as u32;
+                            }
+                            Some(count)
+                        } else {
+                            Some(0)
+                        }
+                    } else {
+                        Some(0)
+                    }
+                } else {
+                    Some(0)
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
 
-		Ok(GitRepoStatus {
-			is_repo: true,
-			current_branch,
-			head_sha,
-			has_remote,
-			remote_url,
-			commits_ahead,
-		})
-	})
-	.await
-	.map_err(|e| format!("Task join error: {}", e))?
+        Ok(GitRepoStatus {
+            is_repo: true,
+            current_branch,
+            head_sha,
+            has_remote,
+            remote_url,
+            commits_ahead,
+        })
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }
 
 /// Setup GitHub integration (init repo, set config, upsert remote)
 #[tauri::command]
 pub async fn git_setup(
-	fs_state: State<'_, crate::fs_commands::FsState>,
-	app: AppHandle,
-	github_repo_url: String,
-	username: String,
-	email: String,
+    fs_state: State<'_, crate::fs_commands::FsState>,
+    app: AppHandle,
+    github_repo_url: String,
+    username: String,
+    email: String,
 ) -> Result<(), String> {
-	let workspace_path = get_workspace_path(&fs_state).await?;
+    let workspace_path = get_workspace_path(&fs_state).await?;
 
-	tokio::task::spawn_blocking(move || {
-		emit_git_progress(&app, "setup", "Setting up GitHub integration...");
-		cleanup_git_locks(&workspace_path);
+    tokio::task::spawn_blocking(move || {
+        emit_git_progress(&app, "setup", "Setting up GitHub integration...");
+        cleanup_git_locks(&workspace_path);
 
-		let repo = ensure_local_repo_scope(&workspace_path)?;
+        let repo = ensure_local_repo_scope(&workspace_path)?;
 
-		// Set user config
-		let mut config = repo.config().map_err(|e| format!("Failed to get config: {}", e))?;
-		config
-			.set_str("user.name", &username)
-			.map_err(|e| format!("Failed to set user.name: {}", e))?;
-		config
-			.set_str("user.email", &email)
-			.map_err(|e| format!("Failed to set user.email: {}", e))?;
+        // Set user config
+        let mut config = repo
+            .config()
+            .map_err(|e| format!("Failed to get config: {}", e))?;
+        config
+            .set_str("user.name", &username)
+            .map_err(|e| format!("Failed to set user.name: {}", e))?;
+        config
+            .set_str("user.email", &email)
+            .map_err(|e| format!("Failed to set user.email: {}", e))?;
 
-		// Upsert remote
-		upsert_remote(&repo, "github-integ", &github_repo_url)?;
+        // Upsert remote
+        upsert_remote(&repo, "github-integ", &github_repo_url)?;
 
-		emit_git_progress(&app, "setup", "GitHub integration configured");
-		Ok(())
-	})
-	.await
-	.map_err(|e| format!("Task join error: {}", e))?
+        emit_git_progress(&app, "setup", "GitHub integration configured");
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }
 
 /// Push changes to GitHub
 #[tauri::command]
 pub async fn git_push(
-	fs_state: State<'_, crate::fs_commands::FsState>,
-	app: AppHandle,
-	access_token: String,
-	github_repo_url: String,
-	branch: String,
-	commit_message: Option<String>,
+    fs_state: State<'_, crate::fs_commands::FsState>,
+    app: AppHandle,
+    access_token: String,
+    github_repo_url: String,
+    branch: String,
+    commit_message: Option<String>,
 ) -> Result<GitPushResponse, String> {
-	let workspace_path = get_workspace_path(&fs_state).await?;
+    let workspace_path = get_workspace_path(&fs_state).await?;
 
-	tokio::task::spawn_blocking(move || {
-		emit_git_progress(&app, "push", "Preparing to push...");
-		cleanup_git_locks(&workspace_path);
+    tokio::task::spawn_blocking(move || {
+        emit_git_progress(&app, "push", "Preparing to push...");
+        cleanup_git_locks(&workspace_path);
 
-		let repo = ensure_local_repo_scope(&workspace_path)?;
+        let repo = ensure_local_repo_scope(&workspace_path)?;
 
-		// Set authenticated remote URL for push
-		let authenticated_url =
-			github_repo_url.replace("https://", &format!("https://{}@", access_token));
-		upsert_remote(&repo, "github-integ", &authenticated_url)?;
+        // Set authenticated remote URL for push
+        let authenticated_url =
+            github_repo_url.replace("https://", &format!("https://{}@", access_token));
+        upsert_remote(&repo, "github-integ", &authenticated_url)?;
 
-		// Ensure we restore the clean remote URL at the end
-		let result = (|| -> Result<GitPushResponse, String> {
-			let msg = commit_message.unwrap_or_else(|| "Sync from Solo IDE".to_string());
+        // Ensure we restore the clean remote URL at the end
+        let result = (|| -> Result<GitPushResponse, String> {
+            let msg = commit_message.unwrap_or_else(|| "Sync from Solo IDE".to_string());
 
-			// Check if we have any commits
-			let has_commits = repo.head().is_ok();
+            // Check if we have any commits
+            let has_commits = repo.head().is_ok();
 
-			if !has_commits {
-				// Fresh repo — need at least one commit to push
-				// Check if there are staged changes to create initial commit from
-				let mut index = repo.index().map_err(|e| format!("Failed to get index: {}", e))?;
-				let statuses = repo
-					.statuses(Some(StatusOptions::new().include_untracked(false)))
-					.map_err(|e| format!("Failed to get status: {}", e))?;
-				let has_changes = statuses.iter().any(|entry| {
-					entry.status().intersects(
-						git2::Status::INDEX_NEW
-							| git2::Status::INDEX_MODIFIED
-							| git2::Status::INDEX_DELETED
-							| git2::Status::INDEX_RENAMED,
-					)
-				});
+            if !has_commits {
+                // Fresh repo — need at least one commit to push
+                // Check if there are staged changes to create initial commit from
+                let mut index = repo
+                    .index()
+                    .map_err(|e| format!("Failed to get index: {}", e))?;
+                let statuses = repo
+                    .statuses(Some(StatusOptions::new().include_untracked(false)))
+                    .map_err(|e| format!("Failed to get status: {}", e))?;
+                let has_changes = statuses.iter().any(|entry| {
+                    entry.status().intersects(
+                        git2::Status::INDEX_NEW
+                            | git2::Status::INDEX_MODIFIED
+                            | git2::Status::INDEX_DELETED
+                            | git2::Status::INDEX_RENAMED,
+                    )
+                });
 
-				emit_git_progress(&app, "push", "Creating initial commit...");
+                emit_git_progress(&app, "push", "Creating initial commit...");
 
-				if !has_changes {
-					return Ok(GitPushResponse { commits_count: 0 });
-				}
+                if !has_changes {
+                    return Ok(GitPushResponse { commits_count: 0 });
+                }
 
-				let sig = repo
-					.signature()
-					.or_else(|_| Signature::now("Solo User", "solo@local"))
-					.map_err(|e| format!("Failed to create signature: {}", e))?;
+                let sig = repo
+                    .signature()
+                    .or_else(|_| Signature::now("Solo User", "solo@local"))
+                    .map_err(|e| format!("Failed to create signature: {}", e))?;
 
-				let tree_oid = index
-					.write_tree()
-					.map_err(|e| format!("Failed to write tree: {}", e))?;
-				let tree = repo
-					.find_tree(tree_oid)
-					.map_err(|e| format!("Failed to find tree: {}", e))?;
+                let tree_oid = index
+                    .write_tree()
+                    .map_err(|e| format!("Failed to write tree: {}", e))?;
+                let tree = repo
+                    .find_tree(tree_oid)
+                    .map_err(|e| format!("Failed to find tree: {}", e))?;
 
-				repo.commit(Some("HEAD"), &sig, &sig, &msg, &tree, &[])
-					.map_err(|e| format!("Failed to create initial commit: {}", e))?;
+                repo.commit(Some("HEAD"), &sig, &sig, &msg, &tree, &[])
+                    .map_err(|e| format!("Failed to create initial commit: {}", e))?;
 
-				// Rename branch to target if needed
-				let head = repo.head().map_err(|e| format!("Failed to get HEAD: {}", e))?;
-				let current_branch = head.shorthand().unwrap_or("master");
-				if current_branch != branch {
-					let head_commit = head.peel_to_commit().map_err(|e| format!("Failed to peel HEAD: {}", e))?;
-					repo.branch(&branch, &head_commit, true)
-						.map_err(|e| format!("Failed to create branch: {}", e))?;
-					repo.set_head(&format!("refs/heads/{}", branch))
-						.map_err(|e| format!("Failed to set HEAD: {}", e))?;
-				}
+                // Rename branch to target if needed
+                let head = repo
+                    .head()
+                    .map_err(|e| format!("Failed to get HEAD: {}", e))?;
+                let current_branch = head.shorthand().unwrap_or("master");
+                if current_branch != branch {
+                    let head_commit = head
+                        .peel_to_commit()
+                        .map_err(|e| format!("Failed to peel HEAD: {}", e))?;
+                    repo.branch(&branch, &head_commit, true)
+                        .map_err(|e| format!("Failed to create branch: {}", e))?;
+                    repo.set_head(&format!("refs/heads/{}", branch))
+                        .map_err(|e| format!("Failed to set HEAD: {}", e))?;
+                }
 
-				emit_git_progress(&app, "push", "Pushing to GitHub...");
+                emit_git_progress(&app, "push", "Pushing to GitHub...");
 
-				let refspec = format!("refs/heads/{}:refs/heads/{}", branch, branch);
-				let mut remote = repo
-					.find_remote("github-integ")
-					.map_err(|e| format!("Failed to find remote: {}", e))?;
-				let mut push_opts = make_push_options(&access_token);
-				remote
-					.push(&[&refspec], Some(&mut push_opts))
-					.map_err(|e| format!("Failed to push: {}", e))?;
+                let refspec = format!("refs/heads/{}:refs/heads/{}", branch, branch);
+                let mut remote = repo
+                    .find_remote("github-integ")
+                    .map_err(|e| format!("Failed to find remote: {}", e))?;
+                let mut push_opts = make_push_options(&access_token);
+                remote
+                    .push(&[&refspec], Some(&mut push_opts))
+                    .map_err(|e| format!("Failed to push: {}", e))?;
 
-				// Update local remote-tracking ref
-				if let Ok(head_ref) = repo.head() {
-					if let Some(oid) = head_ref.target() {
-						let _ = repo.reference(
-							&format!("refs/remotes/github-integ/{}", branch),
-							oid,
-							true,
-							"update after push",
-						);
-					}
-				}
+                // Update local remote-tracking ref
+                if let Ok(head_ref) = repo.head() {
+                    if let Some(oid) = head_ref.target() {
+                        let _ = repo.reference(
+                            &format!("refs/remotes/github-integ/{}", branch),
+                            oid,
+                            true,
+                            "update after push",
+                        );
+                    }
+                }
 
-				emit_git_progress(&app, "push", "Push complete");
-				return Ok(GitPushResponse { commits_count: 1 });
-			}
+                emit_git_progress(&app, "push", "Push complete");
+                return Ok(GitPushResponse { commits_count: 1 });
+            }
 
-			// Fetch from GitHub
-			emit_git_progress(&app, "push", "Fetching from GitHub...");
-			let mut remote = repo
-				.find_remote("github-integ")
-				.map_err(|e| format!("Failed to find remote: {}", e))?;
+            // Fetch from GitHub
+            emit_git_progress(&app, "push", "Fetching from GitHub...");
+            let mut remote = repo
+                .find_remote("github-integ")
+                .map_err(|e| format!("Failed to find remote: {}", e))?;
 
-			let remote_branch_exists = {
-				let mut fetch_opts = make_fetch_options(&access_token);
-				match remote.fetch(&[&branch], Some(&mut fetch_opts), None) {
-					Ok(_) => {
-						let ref_name = format!("refs/remotes/github-integ/{}", branch);
-						repo.refname_to_id(&ref_name).is_ok()
-					}
-					Err(_) => false,
-				}
-			};
+            let remote_branch_exists = {
+                let mut fetch_opts = make_fetch_options(&access_token);
+                match remote.fetch(&[&branch], Some(&mut fetch_opts), None) {
+                    Ok(_) => {
+                        let ref_name = format!("refs/remotes/github-integ/{}", branch);
+                        repo.refname_to_id(&ref_name).is_ok()
+                    }
+                    Err(_) => false,
+                }
+            };
 
-			if remote_branch_exists {
-				let remote_ref = format!("refs/remotes/github-integ/{}", branch);
-				let remote_oid = repo
-					.refname_to_id(&remote_ref)
-					.map_err(|e| format!("Failed to get remote ref: {}", e))?;
+            if remote_branch_exists {
+                let remote_ref = format!("refs/remotes/github-integ/{}", branch);
+                let remote_oid = repo
+                    .refname_to_id(&remote_ref)
+                    .map_err(|e| format!("Failed to get remote ref: {}", e))?;
 
-				let head_oid = repo
-					.head()
-					.map_err(|e| format!("Failed to get HEAD: {}", e))?
-					.target()
-					.ok_or("HEAD has no target")?;
+                let head_oid = repo
+                    .head()
+                    .map_err(|e| format!("Failed to get HEAD: {}", e))?
+                    .target()
+                    .ok_or("HEAD has no target")?;
 
-				// Check if there are differences
-				let remote_commit = repo
-					.find_commit(remote_oid)
-					.map_err(|e| format!("Failed to find remote commit: {}", e))?;
-				let head_commit = repo
-					.find_commit(head_oid)
-					.map_err(|e| format!("Failed to find HEAD commit: {}", e))?;
+                // Check if there are differences
+                let remote_commit = repo
+                    .find_commit(remote_oid)
+                    .map_err(|e| format!("Failed to find remote commit: {}", e))?;
+                let head_commit = repo
+                    .find_commit(head_oid)
+                    .map_err(|e| format!("Failed to find HEAD commit: {}", e))?;
 
-				let remote_tree = remote_commit
-					.tree()
-					.map_err(|e| format!("Failed to get remote tree: {}", e))?;
-				let head_tree = head_commit
-					.tree()
-					.map_err(|e| format!("Failed to get HEAD tree: {}", e))?;
+                let remote_tree = remote_commit
+                    .tree()
+                    .map_err(|e| format!("Failed to get remote tree: {}", e))?;
+                let head_tree = head_commit
+                    .tree()
+                    .map_err(|e| format!("Failed to get HEAD tree: {}", e))?;
 
-				let diff = repo
-					.diff_tree_to_tree(Some(&remote_tree), Some(&head_tree), None)
-					.map_err(|e| format!("Failed to diff: {}", e))?;
+                let diff = repo
+                    .diff_tree_to_tree(Some(&remote_tree), Some(&head_tree), None)
+                    .map_err(|e| format!("Failed to diff: {}", e))?;
 
-				if diff.deltas().count() == 0 {
-					emit_git_progress(&app, "push", "No changes to push");
-					return Ok(GitPushResponse { commits_count: 0 });
-				}
+                if diff.deltas().count() == 0 {
+                    emit_git_progress(&app, "push", "No changes to push");
+                    return Ok(GitPushResponse { commits_count: 0 });
+                }
 
-				emit_git_progress(&app, "push", "Creating synthetic commit...");
+                emit_git_progress(&app, "push", "Creating synthetic commit...");
 
-				// Create a synthetic commit for GitHub
-				let tree_oid = head_commit
-					.tree_id();
-				let tree = repo
-					.find_tree(tree_oid)
-					.map_err(|e| format!("Failed to find tree: {}", e))?;
+                // Create a synthetic commit for GitHub
+                let tree_oid = head_commit.tree_id();
+                let tree = repo
+                    .find_tree(tree_oid)
+                    .map_err(|e| format!("Failed to find tree: {}", e))?;
 
-				let sig = repo
-					.signature()
-					.or_else(|_| Signature::now("Solo User", "solo@local"))
-					.map_err(|e| format!("Failed to create signature: {}", e))?;
+                let sig = repo
+                    .signature()
+                    .or_else(|_| Signature::now("Solo User", "solo@local"))
+                    .map_err(|e| format!("Failed to create signature: {}", e))?;
 
-				let commit_oid = repo
-					.commit(None, &sig, &sig, &msg, &tree, &[&remote_commit])
-					.map_err(|e| format!("Failed to create synthetic commit: {}", e))?;
+                let commit_oid = repo
+                    .commit(None, &sig, &sig, &msg, &tree, &[&remote_commit])
+                    .map_err(|e| format!("Failed to create synthetic commit: {}", e))?;
 
-				emit_git_progress(&app, "push", "Pushing to GitHub...");
+                emit_git_progress(&app, "push", "Pushing to GitHub...");
 
-				// Force push the synthetic commit
-				let refspec = format!("{}:refs/heads/{}", commit_oid, branch);
-				let mut push_opts = make_push_options(&access_token);
+                // Force push the synthetic commit
+                let refspec = format!("{}:refs/heads/{}", commit_oid, branch);
+                let mut push_opts = make_push_options(&access_token);
 
-				// Need a fresh remote handle for the push
-				drop(remote);
-				let mut remote = repo
-					.find_remote("github-integ")
-					.map_err(|e| format!("Failed to find remote: {}", e))?;
+                // Need a fresh remote handle for the push
+                drop(remote);
+                let mut remote = repo
+                    .find_remote("github-integ")
+                    .map_err(|e| format!("Failed to find remote: {}", e))?;
 
-				remote
-					.push(&[&format!("+{}", refspec)], Some(&mut push_opts))
-					.map_err(|e| format!("Failed to push: {}", e))?;
+                remote
+                    .push(&[&format!("+{}", refspec)], Some(&mut push_opts))
+                    .map_err(|e| format!("Failed to push: {}", e))?;
 
-				// Update local ref
-				let _ = repo.reference(
-					&format!("refs/remotes/github-integ/{}", branch),
-					commit_oid,
-					true,
-					"update after push",
-				);
+                // Update local ref
+                let _ = repo.reference(
+                    &format!("refs/remotes/github-integ/{}", branch),
+                    commit_oid,
+                    true,
+                    "update after push",
+                );
 
-				emit_git_progress(&app, "push", "Push complete");
-				Ok(GitPushResponse { commits_count: 1 })
-			} else {
-				// Remote branch doesn't exist — create orphan push
-				emit_git_progress(&app, "push", "Creating initial push...");
+                emit_git_progress(&app, "push", "Push complete");
+                Ok(GitPushResponse { commits_count: 1 })
+            } else {
+                // Remote branch doesn't exist — create orphan push
+                emit_git_progress(&app, "push", "Creating initial push...");
 
-				let head = repo
-					.head()
-					.map_err(|e| format!("Failed to get HEAD: {}", e))?;
-				let head_commit = head
-					.peel_to_commit()
-					.map_err(|e| format!("Failed to peel HEAD: {}", e))?;
+                let head = repo
+                    .head()
+                    .map_err(|e| format!("Failed to get HEAD: {}", e))?;
+                let head_commit = head
+                    .peel_to_commit()
+                    .map_err(|e| format!("Failed to peel HEAD: {}", e))?;
 
-				let tree = head_commit
-					.tree()
-					.map_err(|e| format!("Failed to get tree: {}", e))?;
+                let tree = head_commit
+                    .tree()
+                    .map_err(|e| format!("Failed to get tree: {}", e))?;
 
-				let sig = repo
-					.signature()
-					.or_else(|_| Signature::now("Solo User", "solo@local"))
-					.map_err(|e| format!("Failed to create signature: {}", e))?;
+                let sig = repo
+                    .signature()
+                    .or_else(|_| Signature::now("Solo User", "solo@local"))
+                    .map_err(|e| format!("Failed to create signature: {}", e))?;
 
-				// Orphan commit (no parents)
-				let commit_oid = repo
-					.commit(None, &sig, &sig, &msg, &tree, &[])
-					.map_err(|e| format!("Failed to create orphan commit: {}", e))?;
+                // Orphan commit (no parents)
+                let commit_oid = repo
+                    .commit(None, &sig, &sig, &msg, &tree, &[])
+                    .map_err(|e| format!("Failed to create orphan commit: {}", e))?;
 
-				let refspec = format!("+{}:refs/heads/{}", commit_oid, branch);
-				let mut push_opts = make_push_options(&access_token);
+                let refspec = format!("+{}:refs/heads/{}", commit_oid, branch);
+                let mut push_opts = make_push_options(&access_token);
 
-				drop(remote);
-				let mut remote = repo
-					.find_remote("github-integ")
-					.map_err(|e| format!("Failed to find remote: {}", e))?;
+                drop(remote);
+                let mut remote = repo
+                    .find_remote("github-integ")
+                    .map_err(|e| format!("Failed to find remote: {}", e))?;
 
-				remote
-					.push(&[&refspec], Some(&mut push_opts))
-					.map_err(|e| format!("Failed to push: {}", e))?;
+                remote
+                    .push(&[&refspec], Some(&mut push_opts))
+                    .map_err(|e| format!("Failed to push: {}", e))?;
 
-				// Update local ref
-				let _ = repo.reference(
-					&format!("refs/remotes/github-integ/{}", branch),
-					commit_oid,
-					true,
-					"update after push",
-				);
+                // Update local ref
+                let _ = repo.reference(
+                    &format!("refs/remotes/github-integ/{}", branch),
+                    commit_oid,
+                    true,
+                    "update after push",
+                );
 
-				emit_git_progress(&app, "push", "Push complete");
-				Ok(GitPushResponse { commits_count: 1 })
-			}
-		})();
+                emit_git_progress(&app, "push", "Push complete");
+                Ok(GitPushResponse { commits_count: 1 })
+            }
+        })();
 
-		// Always restore unauthenticated URL
-		let _ = upsert_remote(&repo, "github-integ", &github_repo_url);
+        // Always restore unauthenticated URL
+        let _ = upsert_remote(&repo, "github-integ", &github_repo_url);
 
-		emit_git_changes_updated(&app);
-		result
-	})
-	.await
-	.map_err(|e| format!("Task join error: {}", e))?
+        emit_git_changes_updated(&app);
+        result
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }
 
 /// Pull changes from GitHub
 #[tauri::command]
 pub async fn git_pull(
-	fs_state: State<'_, crate::fs_commands::FsState>,
-	app: AppHandle,
-	access_token: String,
-	github_repo_url: String,
-	branch: String,
-	force_reset: bool,
+    fs_state: State<'_, crate::fs_commands::FsState>,
+    app: AppHandle,
+    access_token: String,
+    github_repo_url: String,
+    branch: String,
+    force_reset: bool,
 ) -> Result<GitPullResponse, String> {
-	let workspace_path = get_workspace_path(&fs_state).await?;
+    let workspace_path = get_workspace_path(&fs_state).await?;
 
-	tokio::task::spawn_blocking(move || {
+    tokio::task::spawn_blocking(move || {
 		emit_git_progress(&app, "pull", "Preparing to pull...");
 		cleanup_git_locks(&workspace_path);
 
@@ -737,24 +738,24 @@ pub async fn git_pull(
 /// Get the current HEAD commit SHA
 #[tauri::command]
 pub async fn git_get_current_sha(
-	fs_state: State<'_, crate::fs_commands::FsState>,
+    fs_state: State<'_, crate::fs_commands::FsState>,
 ) -> Result<String, String> {
-	let workspace_path = get_workspace_path(&fs_state).await?;
+    let workspace_path = get_workspace_path(&fs_state).await?;
 
-	tokio::task::spawn_blocking(move || {
-		let repo = Repository::open(&workspace_path)
-			.map_err(|e| format!("Failed to open repo: {}", e))?;
+    tokio::task::spawn_blocking(move || {
+        let repo =
+            Repository::open(&workspace_path).map_err(|e| format!("Failed to open repo: {}", e))?;
 
-		let head = repo
-			.head()
-			.map_err(|e| format!("Failed to get HEAD: {}", e))?;
+        let head = repo
+            .head()
+            .map_err(|e| format!("Failed to get HEAD: {}", e))?;
 
-		head.target()
-			.map(|oid| oid.to_string())
-			.ok_or_else(|| "HEAD has no target".to_string())
-	})
-	.await
-	.map_err(|e| format!("Task join error: {}", e))?
+        head.target()
+            .map(|oid| oid.to_string())
+            .ok_or_else(|| "HEAD has no target".to_string())
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }
 
 /// Get list of changed files with insertion/deletion stats
@@ -765,790 +766,821 @@ pub async fn git_get_current_sha(
 /// 3. No remote → show uncommitted changes via status
 #[tauri::command]
 pub async fn git_get_changes(
-	fs_state: State<'_, crate::fs_commands::FsState>,
-	branch: Option<String>,
+    fs_state: State<'_, crate::fs_commands::FsState>,
+    branch: Option<String>,
 ) -> Result<GitChangesResponse, String> {
-	let workspace_path = get_workspace_path(&fs_state).await?;
-	let branch = branch.unwrap_or_else(|| "main".to_string());
+    let workspace_path = get_workspace_path(&fs_state).await?;
+    let branch = branch.unwrap_or_else(|| "main".to_string());
 
-	tokio::task::spawn_blocking(move || {
-		let repo = ensure_local_repo_scope(&workspace_path)?;
+    tokio::task::spawn_blocking(move || {
+        let repo = ensure_local_repo_scope(&workspace_path)?;
 
-		let mut files_map: HashMap<String, GitChangedFile> = HashMap::new();
+        let mut files_map: HashMap<String, GitChangedFile> = HashMap::new();
 
-		let (has_remote, has_branch) = get_github_integ_info(&repo, &branch);
+        let (has_remote, has_branch) = get_github_integ_info(&repo, &branch);
 
-		if has_remote && has_branch {
-			// SCENARIO 1: Compare working tree against github-integ/branch
-			let remote_ref = format!("refs/remotes/github-integ/{}", branch);
-			if let Ok(remote_oid) = repo.refname_to_id(&remote_ref) {
-				if let Ok(remote_commit) = repo.find_commit(remote_oid) {
-					if let Ok(remote_tree) = remote_commit.tree() {
-						// Diff remote tree against working directory
-						let mut diff_opts = DiffOptions::new();
-						diff_opts.include_untracked(true);
+        if has_remote && has_branch {
+            // SCENARIO 1: Compare working tree against github-integ/branch
+            let remote_ref = format!("refs/remotes/github-integ/{}", branch);
+            if let Ok(remote_oid) = repo.refname_to_id(&remote_ref) {
+                if let Ok(remote_commit) = repo.find_commit(remote_oid) {
+                    if let Ok(remote_tree) = remote_commit.tree() {
+                        // Diff remote tree against working directory
+                        let mut diff_opts = DiffOptions::new();
+                        diff_opts.include_untracked(true);
 
-						if let Ok(diff) = repo.diff_tree_to_workdir_with_index(
-							Some(&remote_tree),
-							Some(&mut diff_opts),
-						) {
-							for delta_idx in 0..diff.deltas().count() {
-								if let Some(delta) = diff.deltas().nth(delta_idx) {
-									let file_path = delta
-										.new_file()
-										.path()
-										.or_else(|| delta.old_file().path())
-										.and_then(|p| p.to_str())
-										.unwrap_or("")
-										.to_string();
+                        if let Ok(diff) = repo.diff_tree_to_workdir_with_index(
+                            Some(&remote_tree),
+                            Some(&mut diff_opts),
+                        ) {
+                            for delta_idx in 0..diff.deltas().count() {
+                                if let Some(delta) = diff.deltas().nth(delta_idx) {
+                                    let file_path = delta
+                                        .new_file()
+                                        .path()
+                                        .or_else(|| delta.old_file().path())
+                                        .and_then(|p| p.to_str())
+                                        .unwrap_or("")
+                                        .to_string();
 
-									if file_path.is_empty() {
-										continue;
-									}
+                                    if file_path.is_empty() {
+                                        continue;
+                                    }
 
-									let status = match delta.status() {
-										Delta::Added | Delta::Untracked => GitFileStatus::Added,
-										Delta::Deleted => GitFileStatus::Deleted,
-										Delta::Renamed => GitFileStatus::Renamed,
-										_ => GitFileStatus::Modified,
-									};
+                                    let status = match delta.status() {
+                                        Delta::Added | Delta::Untracked => GitFileStatus::Added,
+                                        Delta::Deleted => GitFileStatus::Deleted,
+                                        Delta::Renamed => GitFileStatus::Renamed,
+                                        _ => GitFileStatus::Modified,
+                                    };
 
-									files_map
-										.entry(file_path.clone())
-										.or_insert(GitChangedFile {
-											path: file_path,
-											status,
-											insertions: 0,
-											deletions: 0,
-											is_staged: false,
-										});
-								}
-							}
+                                    files_map
+                                        .entry(file_path.clone())
+                                        .or_insert(GitChangedFile {
+                                            path: file_path,
+                                            status,
+                                            insertions: 0,
+                                            deletions: 0,
+                                            is_staged: false,
+                                        });
+                                }
+                            }
 
-							// Get line stats
-							let _ = diff.foreach(
-								&mut |_delta, _progress| {
-									true
-								},
-								None,
-								Some(&mut |_delta, _hunk| {
-									true
-								}),
-								Some(&mut |delta, _hunk, line| {
-									if let Some(path) = delta
-										.new_file()
-										.path()
-										.or_else(|| delta.old_file().path())
-										.and_then(|p| p.to_str())
-									{
-										if let Some(file) = files_map.get_mut(path) {
-											match line.origin() {
-												'+' => file.insertions += 1,
-												'-' => file.deletions += 1,
-												_ => {}
-											}
-										}
-									}
-									true
-								}),
-							);
-						}
-					}
-				}
-			}
-		} else if has_remote && !has_branch {
-			// SCENARIO 2: Show all tracked + untracked as 'added'
-			let statuses = repo
-				.statuses(Some(StatusOptions::new().include_untracked(true)))
-				.map_err(|e| format!("Failed to get status: {}", e))?;
+                            // Get line stats
+                            let _ = diff.foreach(
+                                &mut |_delta, _progress| true,
+                                None,
+                                Some(&mut |_delta, _hunk| true),
+                                Some(&mut |delta, _hunk, line| {
+                                    if let Some(path) = delta
+                                        .new_file()
+                                        .path()
+                                        .or_else(|| delta.old_file().path())
+                                        .and_then(|p| p.to_str())
+                                    {
+                                        if let Some(file) = files_map.get_mut(path) {
+                                            match line.origin() {
+                                                '+' => file.insertions += 1,
+                                                '-' => file.deletions += 1,
+                                                _ => {}
+                                            }
+                                        }
+                                    }
+                                    true
+                                }),
+                            );
+                        }
+                    }
+                }
+            }
+        } else if has_remote && !has_branch {
+            // SCENARIO 2: Show all tracked + untracked as 'added'
+            let statuses = repo
+                .statuses(Some(StatusOptions::new().include_untracked(true)))
+                .map_err(|e| format!("Failed to get status: {}", e))?;
 
-			for entry in statuses.iter() {
-				let s = entry.status();
-				if s.contains(git2::Status::IGNORED) {
-					continue;
-				}
-				if let Some(path) = entry.path() {
-					files_map
-						.entry(path.to_string())
-						.or_insert(GitChangedFile {
-							path: path.to_string(),
-							status: GitFileStatus::Added,
-							insertions: 0,
-							deletions: 0,
-							is_staged: false,
-						});
-				}
-			}
+            for entry in statuses.iter() {
+                let s = entry.status();
+                if s.contains(git2::Status::IGNORED) {
+                    continue;
+                }
+                if let Some(path) = entry.path() {
+                    files_map.entry(path.to_string()).or_insert(GitChangedFile {
+                        path: path.to_string(),
+                        status: GitFileStatus::Added,
+                        insertions: 0,
+                        deletions: 0,
+                        is_staged: false,
+                    });
+                }
+            }
 
-			// Also add files from index
-			if let Ok(index) = repo.index() {
-				for entry in index.iter() {
-					let path = String::from_utf8_lossy(&entry.path).to_string();
-					files_map
-						.entry(path.clone())
-						.or_insert(GitChangedFile {
-							path,
-							status: GitFileStatus::Added,
-							insertions: 0,
-							deletions: 0,
-							is_staged: false,
-						});
-				}
-			}
-		} else {
-			// SCENARIO 3: No remote — show git status
-			let statuses = repo
-				.statuses(Some(
-					StatusOptions::new()
-						.include_untracked(true)
-						.recurse_untracked_dirs(true),
-				))
-				.map_err(|e| format!("Failed to get status: {}", e))?;
+            // Also add files from index
+            if let Ok(index) = repo.index() {
+                for entry in index.iter() {
+                    let path = String::from_utf8_lossy(&entry.path).to_string();
+                    files_map.entry(path.clone()).or_insert(GitChangedFile {
+                        path,
+                        status: GitFileStatus::Added,
+                        insertions: 0,
+                        deletions: 0,
+                        is_staged: false,
+                    });
+                }
+            }
+        } else {
+            // SCENARIO 3: No remote — show git status
+            let statuses = repo
+                .statuses(Some(
+                    StatusOptions::new()
+                        .include_untracked(true)
+                        .recurse_untracked_dirs(true),
+                ))
+                .map_err(|e| format!("Failed to get status: {}", e))?;
 
-			for entry in statuses.iter() {
-				if let Some(path) = entry.path() {
-					let s = entry.status();
-					if s.contains(git2::Status::IGNORED) {
-						continue;
-					}
-					let status = if s.contains(git2::Status::WT_NEW)
-						|| s.contains(git2::Status::INDEX_NEW)
-					{
-						GitFileStatus::Added
-					} else if s.contains(git2::Status::WT_DELETED)
-						|| s.contains(git2::Status::INDEX_DELETED)
-					{
-						GitFileStatus::Deleted
-					} else if s.contains(git2::Status::INDEX_RENAMED)
-						|| s.contains(git2::Status::WT_RENAMED)
-					{
-						GitFileStatus::Renamed
-					} else {
-						GitFileStatus::Modified
-					};
+            for entry in statuses.iter() {
+                if let Some(path) = entry.path() {
+                    let s = entry.status();
+                    if s.contains(git2::Status::IGNORED) {
+                        continue;
+                    }
+                    let status = if s.contains(git2::Status::WT_NEW)
+                        || s.contains(git2::Status::INDEX_NEW)
+                    {
+                        GitFileStatus::Added
+                    } else if s.contains(git2::Status::WT_DELETED)
+                        || s.contains(git2::Status::INDEX_DELETED)
+                    {
+                        GitFileStatus::Deleted
+                    } else if s.contains(git2::Status::INDEX_RENAMED)
+                        || s.contains(git2::Status::WT_RENAMED)
+                    {
+                        GitFileStatus::Renamed
+                    } else {
+                        GitFileStatus::Modified
+                    };
 
-					files_map
-						.entry(path.to_string())
-						.or_insert(GitChangedFile {
-							path: path.to_string(),
-							status,
-							insertions: 0,
-							deletions: 0,
-							is_staged: false,
-						});
-				}
-			}
+                    files_map.entry(path.to_string()).or_insert(GitChangedFile {
+                        path: path.to_string(),
+                        status,
+                        insertions: 0,
+                        deletions: 0,
+                        is_staged: false,
+                    });
+                }
+            }
 
-			// Get line stats from HEAD diff
-			if let Ok(head) = repo.head() {
-				if let Ok(head_commit) = head.peel_to_commit() {
-					if let Ok(head_tree) = head_commit.tree() {
-						if let Ok(diff) = repo.diff_tree_to_workdir_with_index(Some(&head_tree), None) {
-							let _ = diff.foreach(
-								&mut |_delta, _progress| true,
-								None,
-								Some(&mut |_delta, _hunk| true),
-								Some(&mut |delta, _hunk, line| {
-									if let Some(path) = delta
-										.new_file()
-										.path()
-										.or_else(|| delta.old_file().path())
-										.and_then(|p| p.to_str())
-									{
-										if let Some(file) = files_map.get_mut(path) {
-											match line.origin() {
-												'+' => file.insertions += 1,
-												'-' => file.deletions += 1,
-												_ => {}
-											}
-										}
-									}
-									true
-								}),
-							);
-						}
-					}
-				}
-			}
-		}
+            // Get line stats from HEAD diff
+            if let Ok(head) = repo.head() {
+                if let Ok(head_commit) = head.peel_to_commit() {
+                    if let Ok(head_tree) = head_commit.tree() {
+                        if let Ok(diff) =
+                            repo.diff_tree_to_workdir_with_index(Some(&head_tree), None)
+                        {
+                            let _ = diff.foreach(
+                                &mut |_delta, _progress| true,
+                                None,
+                                Some(&mut |_delta, _hunk| true),
+                                Some(&mut |delta, _hunk, line| {
+                                    if let Some(path) = delta
+                                        .new_file()
+                                        .path()
+                                        .or_else(|| delta.old_file().path())
+                                        .and_then(|p| p.to_str())
+                                    {
+                                        if let Some(file) = files_map.get_mut(path) {
+                                            match line.origin() {
+                                                '+' => file.insertions += 1,
+                                                '-' => file.deletions += 1,
+                                                _ => {}
+                                            }
+                                        }
+                                    }
+                                    true
+                                }),
+                            );
+                        }
+                    }
+                }
+            }
+        }
 
-		// Detect staging state from git index
-		let statuses = repo
-			.statuses(Some(StatusOptions::new().include_untracked(true).recurse_untracked_dirs(true)))
-			.ok();
+        // Detect staging state from git index
+        let statuses = repo
+            .statuses(Some(
+                StatusOptions::new()
+                    .include_untracked(true)
+                    .recurse_untracked_dirs(true),
+            ))
+            .ok();
 
-		if let Some(ref statuses) = statuses {
-			for entry in statuses.iter() {
-				if let Some(path) = entry.path() {
-					let s = entry.status();
-					let is_staged = s.intersects(
-						git2::Status::INDEX_NEW
-							| git2::Status::INDEX_MODIFIED
-							| git2::Status::INDEX_DELETED
-							| git2::Status::INDEX_RENAMED,
-					);
-					if let Some(file) = files_map.get_mut(path) {
-						file.is_staged = is_staged;
-					}
-				}
-			}
-		}
+        if let Some(ref statuses) = statuses {
+            for entry in statuses.iter() {
+                if let Some(path) = entry.path() {
+                    let s = entry.status();
+                    let is_staged = s.intersects(
+                        git2::Status::INDEX_NEW
+                            | git2::Status::INDEX_MODIFIED
+                            | git2::Status::INDEX_DELETED
+                            | git2::Status::INDEX_RENAMED,
+                    );
+                    if let Some(file) = files_map.get_mut(path) {
+                        file.is_staged = is_staged;
+                    }
+                }
+            }
+        }
 
-		let mut files: Vec<GitChangedFile> = files_map.into_values().collect();
-		files.sort_by(|a, b| a.path.cmp(&b.path));
+        let mut files: Vec<GitChangedFile> = files_map.into_values().collect();
+        files.sort_by(|a, b| a.path.cmp(&b.path));
 
-		let summary = GitChangesSummary {
-			insertions: files.iter().map(|f| f.insertions).sum(),
-			deletions: files.iter().map(|f| f.deletions).sum(),
-		};
+        let summary = GitChangesSummary {
+            insertions: files.iter().map(|f| f.insertions).sum(),
+            deletions: files.iter().map(|f| f.deletions).sum(),
+        };
 
-		Ok(GitChangesResponse { files, summary })
-	})
-	.await
-	.map_err(|e| format!("Task join error: {}", e))?
+        Ok(GitChangesResponse { files, summary })
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }
 
 /// Get old and new content for a file diff
 #[tauri::command]
 pub async fn git_get_file_diff(
-	fs_state: State<'_, crate::fs_commands::FsState>,
-	file_path: String,
-	branch: Option<String>,
+    fs_state: State<'_, crate::fs_commands::FsState>,
+    file_path: String,
+    branch: Option<String>,
 ) -> Result<GitFileDiffResponse, String> {
-	let workspace_path = get_workspace_path(&fs_state).await?;
-	let branch = branch.unwrap_or_else(|| "main".to_string());
+    let workspace_path = get_workspace_path(&fs_state).await?;
+    let branch = branch.unwrap_or_else(|| "main".to_string());
 
-	tokio::task::spawn_blocking(move || {
-		let repo = ensure_local_repo_scope(&workspace_path)?;
+    tokio::task::spawn_blocking(move || {
+        let repo = ensure_local_repo_scope(&workspace_path)?;
 
-		let (has_remote, has_branch) = get_github_integ_info(&repo, &branch);
-		let base_ref = if has_remote && has_branch {
-			format!("github-integ/{}", branch)
-		} else {
-			"HEAD".to_string()
-		};
+        let (has_remote, has_branch) = get_github_integ_info(&repo, &branch);
+        let base_ref = if has_remote && has_branch {
+            format!("github-integ/{}", branch)
+        } else {
+            "HEAD".to_string()
+        };
 
-		// Read current file content
-		let full_path = workspace_path.join(&file_path);
-		let new_content = if full_path.exists() {
-			std::fs::read_to_string(&full_path).unwrap_or_default()
-		} else {
-			String::new()
-		};
+        // Read current file content
+        let full_path = workspace_path.join(&file_path);
+        let new_content = if full_path.exists() {
+            std::fs::read_to_string(&full_path).unwrap_or_default()
+        } else {
+            String::new()
+        };
 
-		// Check if file is untracked/new
-		if let Ok(statuses) = repo.statuses(None) {
-			for entry in statuses.iter() {
-				if entry.path() == Some(&file_path) {
-					let s = entry.status();
-					if s.contains(git2::Status::WT_NEW) || s.contains(git2::Status::INDEX_NEW) {
-						return Ok(GitFileDiffResponse {
-							old_content: String::new(),
-							new_content,
-						});
-					}
-				}
-			}
-		}
+        // Check if file is untracked/new
+        if let Ok(statuses) = repo.statuses(None) {
+            for entry in statuses.iter() {
+                if entry.path() == Some(&file_path) {
+                    let s = entry.status();
+                    if s.contains(git2::Status::WT_NEW) || s.contains(git2::Status::INDEX_NEW) {
+                        return Ok(GitFileDiffResponse {
+                            old_content: String::new(),
+                            new_content,
+                        });
+                    }
+                }
+            }
+        }
 
-		// Try to get old content from base ref
-		let old_content = get_blob_content(&repo, &base_ref, &file_path)
-			.or_else(|| {
-				if base_ref != "HEAD" {
-					get_blob_content(&repo, "HEAD", &file_path)
-				} else {
-					None
-				}
-			})
-			.unwrap_or_default();
+        // Try to get old content from base ref
+        let old_content = get_blob_content(&repo, &base_ref, &file_path)
+            .or_else(|| {
+                if base_ref != "HEAD" {
+                    get_blob_content(&repo, "HEAD", &file_path)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_default();
 
-		Ok(GitFileDiffResponse {
-			old_content,
-			new_content,
-		})
-	})
-	.await
-	.map_err(|e| format!("Task join error: {}", e))?
+        Ok(GitFileDiffResponse {
+            old_content,
+            new_content,
+        })
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }
 
 /// Get blob content from a tree spec like "HEAD:path/to/file"
 fn get_blob_content(repo: &Repository, treeish: &str, file_path: &str) -> Option<String> {
-	let spec = format!("{}:{}", treeish, file_path);
-	let obj = repo.revparse_single(&spec).ok()?;
-	let blob = obj.peel_to_blob().ok()?;
-	String::from_utf8(blob.content().to_vec()).ok()
+    let spec = format!("{}:{}", treeish, file_path);
+    let obj = repo.revparse_single(&spec).ok()?;
+    let blob = obj.peel_to_blob().ok()?;
+    String::from_utf8(blob.content().to_vec()).ok()
 }
 
 /// Discard changes for a specific file
 #[tauri::command]
 pub async fn git_discard_file(
-	fs_state: State<'_, crate::fs_commands::FsState>,
-	app: AppHandle,
-	file_path: String,
-	branch: Option<String>,
+    fs_state: State<'_, crate::fs_commands::FsState>,
+    app: AppHandle,
+    file_path: String,
+    branch: Option<String>,
 ) -> Result<(), String> {
-	let workspace_path = get_workspace_path(&fs_state).await?;
-	let branch = branch.unwrap_or_else(|| "main".to_string());
+    let workspace_path = get_workspace_path(&fs_state).await?;
+    let branch = branch.unwrap_or_else(|| "main".to_string());
 
-	tokio::task::spawn_blocking(move || {
-		let repo = ensure_local_repo_scope(&workspace_path)?;
+    tokio::task::spawn_blocking(move || {
+        let repo = ensure_local_repo_scope(&workspace_path)?;
 
-		let full_path = workspace_path.join(&file_path);
-		let (has_remote, has_branch) = get_github_integ_info(&repo, &branch);
+        let full_path = workspace_path.join(&file_path);
+        let (has_remote, has_branch) = get_github_integ_info(&repo, &branch);
 
-		// Check if file is untracked
-		if let Ok(statuses) = repo.statuses(None) {
-			for entry in statuses.iter() {
-				if entry.path() == Some(file_path.as_str()) {
-					let s = entry.status();
-					if s.contains(git2::Status::WT_NEW) {
-						// Untracked file — delete it
-						if full_path.exists() {
-							std::fs::remove_file(&full_path)
-								.map_err(|e| format!("Failed to delete file: {}", e))?;
-						}
-						emit_git_changes_updated(&app);
-						return Ok(());
-					}
-				}
-			}
-		}
+        // Check if file is untracked
+        if let Ok(statuses) = repo.statuses(None) {
+            for entry in statuses.iter() {
+                if entry.path() == Some(file_path.as_str()) {
+                    let s = entry.status();
+                    if s.contains(git2::Status::WT_NEW) {
+                        // Untracked file — delete it
+                        if full_path.exists() {
+                            std::fs::remove_file(&full_path)
+                                .map_err(|e| format!("Failed to delete file: {}", e))?;
+                        }
+                        emit_git_changes_updated(&app);
+                        return Ok(());
+                    }
+                }
+            }
+        }
 
-		// Try to restore from github-integ or HEAD
-		let base_ref = if has_remote && has_branch {
-			format!("github-integ/{}", branch)
-		} else {
-			"HEAD".to_string()
-		};
+        // Try to restore from github-integ or HEAD
+        let base_ref = if has_remote && has_branch {
+            format!("github-integ/{}", branch)
+        } else {
+            "HEAD".to_string()
+        };
 
-		if let Some(content) = get_blob_content(&repo, &base_ref, &file_path) {
-			std::fs::write(&full_path, content)
-				.map_err(|e| format!("Failed to write file: {}", e))?;
+        if let Some(content) = get_blob_content(&repo, &base_ref, &file_path) {
+            std::fs::write(&full_path, content)
+                .map_err(|e| format!("Failed to write file: {}", e))?;
 
-			// Reset index entry
-			let mut index = repo.index().map_err(|e| format!("Failed to get index: {}", e))?;
-			let _ = index.add_path(Path::new(&file_path));
-			let _ = index.write();
+            // Reset index entry
+            let mut index = repo
+                .index()
+                .map_err(|e| format!("Failed to get index: {}", e))?;
+            let _ = index.add_path(Path::new(&file_path));
+            let _ = index.write();
 
-			emit_git_changes_updated(&app);
-			return Ok(());
-		}
+            emit_git_changes_updated(&app);
+            return Ok(());
+        }
 
-		// Try HEAD as fallback
-		if base_ref != "HEAD" {
-			if let Some(content) = get_blob_content(&repo, "HEAD", &file_path) {
-				std::fs::write(&full_path, content)
-					.map_err(|e| format!("Failed to write file: {}", e))?;
-				emit_git_changes_updated(&app);
-				return Ok(());
-			}
-		}
+        // Try HEAD as fallback
+        if base_ref != "HEAD" {
+            if let Some(content) = get_blob_content(&repo, "HEAD", &file_path) {
+                std::fs::write(&full_path, content)
+                    .map_err(|e| format!("Failed to write file: {}", e))?;
+                emit_git_changes_updated(&app);
+                return Ok(());
+            }
+        }
 
-		// For deleted files — try to restore
-		if !full_path.exists() {
-			let restore_ref = if has_remote && has_branch {
-				format!("github-integ/{}", branch)
-			} else {
-				"HEAD".to_string()
-			};
+        // For deleted files — try to restore
+        if !full_path.exists() {
+            let restore_ref = if has_remote && has_branch {
+                format!("github-integ/{}", branch)
+            } else {
+                "HEAD".to_string()
+            };
 
-			if let Some(content) = get_blob_content(&repo, &restore_ref, &file_path) {
-				// Ensure parent directory exists
-				if let Some(parent) = full_path.parent() {
-					let _ = std::fs::create_dir_all(parent);
-				}
-				std::fs::write(&full_path, content)
-					.map_err(|e| format!("Failed to restore file: {}", e))?;
-				emit_git_changes_updated(&app);
-				return Ok(());
-			}
+            if let Some(content) = get_blob_content(&repo, &restore_ref, &file_path) {
+                // Ensure parent directory exists
+                if let Some(parent) = full_path.parent() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
+                std::fs::write(&full_path, content)
+                    .map_err(|e| format!("Failed to restore file: {}", e))?;
+                emit_git_changes_updated(&app);
+                return Ok(());
+            }
 
-			return Err(format!(
-				"Cannot restore file {}: not found in git history",
-				file_path
-			));
-		}
+            return Err(format!(
+                "Cannot restore file {}: not found in git history",
+                file_path
+            ));
+        }
 
-		emit_git_changes_updated(&app);
-		Ok(())
-	})
-	.await
-	.map_err(|e| format!("Task join error: {}", e))?
+        emit_git_changes_updated(&app);
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }
 
 /// Discard all changes
 #[tauri::command]
 pub async fn git_discard_all(
-	fs_state: State<'_, crate::fs_commands::FsState>,
-	app: AppHandle,
-	branch: Option<String>,
+    fs_state: State<'_, crate::fs_commands::FsState>,
+    app: AppHandle,
+    branch: Option<String>,
 ) -> Result<(), String> {
-	let workspace_path = get_workspace_path(&fs_state).await?;
-	let branch = branch.unwrap_or_else(|| "main".to_string());
+    let workspace_path = get_workspace_path(&fs_state).await?;
+    let branch = branch.unwrap_or_else(|| "main".to_string());
 
-	tokio::task::spawn_blocking(move || {
-		let repo = ensure_local_repo_scope(&workspace_path)?;
+    tokio::task::spawn_blocking(move || {
+        let repo = ensure_local_repo_scope(&workspace_path)?;
 
-		let (has_remote, has_branch) = get_github_integ_info(&repo, &branch);
+        let (has_remote, has_branch) = get_github_integ_info(&repo, &branch);
 
-		if has_remote && has_branch {
-			// Reset to github-integ version
-			let remote_ref = format!("refs/remotes/github-integ/{}", branch);
-			if let Ok(remote_oid) = repo.refname_to_id(&remote_ref) {
-				if let Ok(obj) = repo.find_object(remote_oid, None) {
-					repo.reset(&obj, ResetType::Hard, None)
-						.map_err(|e| format!("Failed to reset: {}", e))?;
+        if has_remote && has_branch {
+            // Reset to github-integ version
+            let remote_ref = format!("refs/remotes/github-integ/{}", branch);
+            if let Ok(remote_oid) = repo.refname_to_id(&remote_ref) {
+                if let Ok(obj) = repo.find_object(remote_oid, None) {
+                    repo.reset(&obj, ResetType::Hard, None)
+                        .map_err(|e| format!("Failed to reset: {}", e))?;
 
-					// Clean untracked files
-					clean_untracked(&workspace_path, &repo);
+                    // Clean untracked files
+                    clean_untracked(&workspace_path, &repo);
 
-					emit_git_changes_updated(&app);
-					return Ok(());
-				}
-			}
-		}
+                    emit_git_changes_updated(&app);
+                    return Ok(());
+                }
+            }
+        }
 
-		// Fallback: reset to HEAD
-		if let Ok(head) = repo.head() {
-			if let Some(oid) = head.target() {
-				if let Ok(obj) = repo.find_object(oid, None) {
-					let _ = repo.reset(&obj, ResetType::Hard, None);
-				}
-			}
-		}
+        // Fallback: reset to HEAD
+        if let Ok(head) = repo.head() {
+            if let Some(oid) = head.target() {
+                if let Ok(obj) = repo.find_object(oid, None) {
+                    let _ = repo.reset(&obj, ResetType::Hard, None);
+                }
+            }
+        }
 
-		// Clean untracked
-		clean_untracked(&workspace_path, &repo);
+        // Clean untracked
+        clean_untracked(&workspace_path, &repo);
 
-		emit_git_changes_updated(&app);
-		Ok(())
-	})
-	.await
-	.map_err(|e| format!("Task join error: {}", e))?
+        emit_git_changes_updated(&app);
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }
 
 /// Remove untracked files from the working directory
 fn clean_untracked(workspace_path: &Path, repo: &Repository) {
-	if let Ok(statuses) = repo.statuses(Some(StatusOptions::new().include_untracked(true))) {
-		for entry in statuses.iter() {
-			let s = entry.status();
-			if s.contains(git2::Status::WT_NEW) {
-				if let Some(path) = entry.path() {
-					let full_path = workspace_path.join(path);
-					if full_path.is_dir() {
-						let _ = std::fs::remove_dir_all(&full_path);
-					} else {
-						let _ = std::fs::remove_file(&full_path);
-					}
-				}
-			}
-		}
-	}
+    if let Ok(statuses) = repo.statuses(Some(StatusOptions::new().include_untracked(true))) {
+        for entry in statuses.iter() {
+            let s = entry.status();
+            if s.contains(git2::Status::WT_NEW) {
+                if let Some(path) = entry.path() {
+                    let full_path = workspace_path.join(path);
+                    if full_path.is_dir() {
+                        let _ = std::fs::remove_dir_all(&full_path);
+                    } else {
+                        let _ = std::fs::remove_file(&full_path);
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Clean up stale git lock files
 #[tauri::command]
 pub async fn git_cleanup_locks(
-	fs_state: State<'_, crate::fs_commands::FsState>,
+    fs_state: State<'_, crate::fs_commands::FsState>,
 ) -> Result<(), String> {
-	let workspace_path = get_workspace_path(&fs_state).await?;
+    let workspace_path = get_workspace_path(&fs_state).await?;
 
-	tokio::task::spawn_blocking(move || {
-		cleanup_git_locks(&workspace_path);
-		Ok(())
-	})
-	.await
-	.map_err(|e| format!("Task join error: {}", e))?
+    tokio::task::spawn_blocking(move || {
+        cleanup_git_locks(&workspace_path);
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }
 
 /// Stage a file (git add)
 #[tauri::command]
 pub async fn git_stage_file(
-	fs_state: State<'_, crate::fs_commands::FsState>,
-	app: AppHandle,
-	file_path: String,
+    fs_state: State<'_, crate::fs_commands::FsState>,
+    app: AppHandle,
+    file_path: String,
 ) -> Result<(), String> {
-	let workspace_path = get_workspace_path(&fs_state).await?;
+    let workspace_path = get_workspace_path(&fs_state).await?;
 
-	tokio::task::spawn_blocking(move || {
-		let repo = Repository::open(&workspace_path)
-			.map_err(|e| format!("Failed to open repo: {}", e))?;
+    tokio::task::spawn_blocking(move || {
+        let repo =
+            Repository::open(&workspace_path).map_err(|e| format!("Failed to open repo: {}", e))?;
 
-		let mut index = repo.index().map_err(|e| format!("Failed to get index: {}", e))?;
+        let mut index = repo
+            .index()
+            .map_err(|e| format!("Failed to get index: {}", e))?;
 
-		let full_path = workspace_path.join(&file_path);
-		if full_path.exists() {
-			index
-				.add_path(Path::new(&file_path))
-				.map_err(|e| format!("Failed to stage file: {}", e))?;
-		} else {
-			// File was deleted — remove from index
-			index
-				.remove_path(Path::new(&file_path))
-				.map_err(|e| format!("Failed to stage deleted file: {}", e))?;
-		}
+        let full_path = workspace_path.join(&file_path);
+        if full_path.exists() {
+            index
+                .add_path(Path::new(&file_path))
+                .map_err(|e| format!("Failed to stage file: {}", e))?;
+        } else {
+            // File was deleted — remove from index
+            index
+                .remove_path(Path::new(&file_path))
+                .map_err(|e| format!("Failed to stage deleted file: {}", e))?;
+        }
 
-		index.write().map_err(|e| format!("Failed to write index: {}", e))?;
+        index
+            .write()
+            .map_err(|e| format!("Failed to write index: {}", e))?;
 
-		emit_git_changes_updated(&app);
-		Ok(())
-	})
-	.await
-	.map_err(|e| format!("Task join error: {}", e))?
+        emit_git_changes_updated(&app);
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }
 
 /// Unstage a file (git reset HEAD -- file)
 #[tauri::command]
 pub async fn git_unstage_file(
-	fs_state: State<'_, crate::fs_commands::FsState>,
-	app: AppHandle,
-	file_path: String,
+    fs_state: State<'_, crate::fs_commands::FsState>,
+    app: AppHandle,
+    file_path: String,
 ) -> Result<(), String> {
-	let workspace_path = get_workspace_path(&fs_state).await?;
+    let workspace_path = get_workspace_path(&fs_state).await?;
 
-	tokio::task::spawn_blocking(move || {
-		let repo = Repository::open(&workspace_path)
-			.map_err(|e| format!("Failed to open repo: {}", e))?;
+    tokio::task::spawn_blocking(move || {
+        let repo =
+            Repository::open(&workspace_path).map_err(|e| format!("Failed to open repo: {}", e))?;
 
-		// Try to reset from HEAD; if no HEAD (fresh repo), remove from index
-		let head_result = repo.head();
-		let mut index = repo.index().map_err(|e| format!("Failed to get index: {}", e))?;
+        // Try to reset from HEAD; if no HEAD (fresh repo), remove from index
+        let head_result = repo.head();
+        let mut index = repo
+            .index()
+            .map_err(|e| format!("Failed to get index: {}", e))?;
 
-		if let Ok(head) = head_result {
-			if let Ok(commit) = head.peel_to_commit() {
-				if let Ok(tree) = commit.tree() {
-					// Check if file exists in HEAD
-					if let Ok(entry) = tree.get_path(Path::new(&file_path)) {
-						// Restore the index entry from HEAD
-						let obj = entry.to_object(&repo)
-							.map_err(|e| format!("Failed to get object: {}", e))?;
-						let blob = obj.peel_to_blob()
-							.map_err(|e| format!("Failed to get blob: {}", e))?;
+        if let Ok(head) = head_result {
+            if let Ok(commit) = head.peel_to_commit() {
+                if let Ok(tree) = commit.tree() {
+                    // Check if file exists in HEAD
+                    if let Ok(entry) = tree.get_path(Path::new(&file_path)) {
+                        // Restore the index entry from HEAD
+                        let obj = entry
+                            .to_object(&repo)
+                            .map_err(|e| format!("Failed to get object: {}", e))?;
+                        let blob = obj
+                            .peel_to_blob()
+                            .map_err(|e| format!("Failed to get blob: {}", e))?;
 
-						let idx_entry = git2::IndexEntry {
-							ctime: git2::IndexTime::new(0, 0),
-							mtime: git2::IndexTime::new(0, 0),
-							dev: 0,
-							ino: 0,
-							mode: entry.filemode() as u32,
-							uid: 0,
-							gid: 0,
-							file_size: blob.size() as u32,
-							id: blob.id(),
-							flags: 0,
-							flags_extended: 0,
-							path: file_path.as_bytes().to_vec(),
-						};
-						index.add(&idx_entry)
-							.map_err(|e| format!("Failed to restore index entry: {}", e))?;
-					} else {
-						// File doesn't exist in HEAD — remove from index
-						index.remove_path(Path::new(&file_path))
-							.map_err(|e| format!("Failed to remove from index: {}", e))?;
-					}
-				}
-			}
-		} else {
-			// No HEAD (fresh repo) — just remove from index
-			index.remove_path(Path::new(&file_path))
-				.map_err(|e| format!("Failed to remove from index: {}", e))?;
-		}
+                        let idx_entry = git2::IndexEntry {
+                            ctime: git2::IndexTime::new(0, 0),
+                            mtime: git2::IndexTime::new(0, 0),
+                            dev: 0,
+                            ino: 0,
+                            mode: entry.filemode() as u32,
+                            uid: 0,
+                            gid: 0,
+                            file_size: blob.size() as u32,
+                            id: blob.id(),
+                            flags: 0,
+                            flags_extended: 0,
+                            path: file_path.as_bytes().to_vec(),
+                        };
+                        index
+                            .add(&idx_entry)
+                            .map_err(|e| format!("Failed to restore index entry: {}", e))?;
+                    } else {
+                        // File doesn't exist in HEAD — remove from index
+                        index
+                            .remove_path(Path::new(&file_path))
+                            .map_err(|e| format!("Failed to remove from index: {}", e))?;
+                    }
+                }
+            }
+        } else {
+            // No HEAD (fresh repo) — just remove from index
+            index
+                .remove_path(Path::new(&file_path))
+                .map_err(|e| format!("Failed to remove from index: {}", e))?;
+        }
 
-		index.write().map_err(|e| format!("Failed to write index: {}", e))?;
+        index
+            .write()
+            .map_err(|e| format!("Failed to write index: {}", e))?;
 
-		emit_git_changes_updated(&app);
-		Ok(())
-	})
-	.await
-	.map_err(|e| format!("Task join error: {}", e))?
+        emit_git_changes_updated(&app);
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }
 
 /// Stage all files (git add .)
 #[tauri::command]
 pub async fn git_stage_all(
-	fs_state: State<'_, crate::fs_commands::FsState>,
-	app: AppHandle,
+    fs_state: State<'_, crate::fs_commands::FsState>,
+    app: AppHandle,
 ) -> Result<(), String> {
-	let workspace_path = get_workspace_path(&fs_state).await?;
+    let workspace_path = get_workspace_path(&fs_state).await?;
 
-	tokio::task::spawn_blocking(move || {
-		let repo = Repository::open(&workspace_path)
-			.map_err(|e| format!("Failed to open repo: {}", e))?;
+    tokio::task::spawn_blocking(move || {
+        let repo =
+            Repository::open(&workspace_path).map_err(|e| format!("Failed to open repo: {}", e))?;
 
-		let mut index = repo.index().map_err(|e| format!("Failed to get index: {}", e))?;
-		index
-			.add_all(["*"].iter(), IndexAddOption::DEFAULT, None)
-			.map_err(|e| format!("Failed to stage all files: {}", e))?;
+        let mut index = repo
+            .index()
+            .map_err(|e| format!("Failed to get index: {}", e))?;
+        index
+            .add_all(["*"].iter(), IndexAddOption::DEFAULT, None)
+            .map_err(|e| format!("Failed to stage all files: {}", e))?;
 
-		// Also handle deleted files
-		let statuses = repo
-			.statuses(Some(StatusOptions::new().include_untracked(false)))
-			.map_err(|e| format!("Failed to get status: {}", e))?;
-		for entry in statuses.iter() {
-			let s = entry.status();
-			if s.contains(git2::Status::WT_DELETED) {
-				if let Some(path) = entry.path() {
-					let _ = index.remove_path(Path::new(path));
-				}
-			}
-		}
+        // Also handle deleted files
+        let statuses = repo
+            .statuses(Some(StatusOptions::new().include_untracked(false)))
+            .map_err(|e| format!("Failed to get status: {}", e))?;
+        for entry in statuses.iter() {
+            let s = entry.status();
+            if s.contains(git2::Status::WT_DELETED) {
+                if let Some(path) = entry.path() {
+                    let _ = index.remove_path(Path::new(path));
+                }
+            }
+        }
 
-		index.write().map_err(|e| format!("Failed to write index: {}", e))?;
+        index
+            .write()
+            .map_err(|e| format!("Failed to write index: {}", e))?;
 
-		emit_git_changes_updated(&app);
-		Ok(())
-	})
-	.await
-	.map_err(|e| format!("Task join error: {}", e))?
+        emit_git_changes_updated(&app);
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }
 
 /// Commit staged changes locally (no push)
 #[tauri::command]
 pub async fn git_commit(
-	fs_state: State<'_, crate::fs_commands::FsState>,
-	app: AppHandle,
-	commit_message: String,
+    fs_state: State<'_, crate::fs_commands::FsState>,
+    app: AppHandle,
+    commit_message: String,
 ) -> Result<(), String> {
-	let workspace_path = get_workspace_path(&fs_state).await?;
+    let workspace_path = get_workspace_path(&fs_state).await?;
 
-	tokio::task::spawn_blocking(move || {
-		cleanup_git_locks(&workspace_path);
+    tokio::task::spawn_blocking(move || {
+        cleanup_git_locks(&workspace_path);
 
-		let repo = Repository::open(&workspace_path)
-			.map_err(|e| format!("Failed to open repo: {}", e))?;
+        let repo =
+            Repository::open(&workspace_path).map_err(|e| format!("Failed to open repo: {}", e))?;
 
-		let mut index = repo.index().map_err(|e| format!("Failed to get index: {}", e))?;
+        let mut index = repo
+            .index()
+            .map_err(|e| format!("Failed to get index: {}", e))?;
 
-		// Check for staged changes
-		let statuses = repo
-			.statuses(Some(StatusOptions::new().include_untracked(false)))
-			.map_err(|e| format!("Failed to get status: {}", e))?;
+        // Check for staged changes
+        let statuses = repo
+            .statuses(Some(StatusOptions::new().include_untracked(false)))
+            .map_err(|e| format!("Failed to get status: {}", e))?;
 
-		let has_staged = statuses.iter().any(|entry| {
-			entry.status().intersects(
-				git2::Status::INDEX_NEW
-					| git2::Status::INDEX_MODIFIED
-					| git2::Status::INDEX_DELETED
-					| git2::Status::INDEX_RENAMED,
-			)
-		});
+        let has_staged = statuses.iter().any(|entry| {
+            entry.status().intersects(
+                git2::Status::INDEX_NEW
+                    | git2::Status::INDEX_MODIFIED
+                    | git2::Status::INDEX_DELETED
+                    | git2::Status::INDEX_RENAMED,
+            )
+        });
 
-		if !has_staged {
-			return Err("No staged changes to commit".to_string());
-		}
+        if !has_staged {
+            return Err("No staged changes to commit".to_string());
+        }
 
-		let sig = repo
-			.signature()
-			.or_else(|_| Signature::now("Solo User", "solo@local"))
-			.map_err(|e| format!("Failed to create signature: {}", e))?;
+        let sig = repo
+            .signature()
+            .or_else(|_| Signature::now("Solo User", "solo@local"))
+            .map_err(|e| format!("Failed to create signature: {}", e))?;
 
-		let tree_oid = index
-			.write_tree()
-			.map_err(|e| format!("Failed to write tree: {}", e))?;
-		let tree = repo
-			.find_tree(tree_oid)
-			.map_err(|e| format!("Failed to find tree: {}", e))?;
+        let tree_oid = index
+            .write_tree()
+            .map_err(|e| format!("Failed to write tree: {}", e))?;
+        let tree = repo
+            .find_tree(tree_oid)
+            .map_err(|e| format!("Failed to find tree: {}", e))?;
 
-		if let Ok(head) = repo.head() {
-			let parent = head
-				.peel_to_commit()
-				.map_err(|e| format!("Failed to peel HEAD: {}", e))?;
-			repo.commit(Some("HEAD"), &sig, &sig, &commit_message, &tree, &[&parent])
-				.map_err(|e| format!("Failed to commit: {}", e))?;
-		} else {
-			// Fresh repo — no parent
-			repo.commit(Some("HEAD"), &sig, &sig, &commit_message, &tree, &[])
-				.map_err(|e| format!("Failed to create initial commit: {}", e))?;
-		}
+        if let Ok(head) = repo.head() {
+            let parent = head
+                .peel_to_commit()
+                .map_err(|e| format!("Failed to peel HEAD: {}", e))?;
+            repo.commit(Some("HEAD"), &sig, &sig, &commit_message, &tree, &[&parent])
+                .map_err(|e| format!("Failed to commit: {}", e))?;
+        } else {
+            // Fresh repo — no parent
+            repo.commit(Some("HEAD"), &sig, &sig, &commit_message, &tree, &[])
+                .map_err(|e| format!("Failed to create initial commit: {}", e))?;
+        }
 
-		emit_git_changes_updated(&app);
-		Ok(())
-	})
-	.await
-	.map_err(|e| format!("Task join error: {}", e))?
+        emit_git_changes_updated(&app);
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }
 
 /// Unstage all files (git reset HEAD)
 #[tauri::command]
 pub async fn git_unstage_all(
-	fs_state: State<'_, crate::fs_commands::FsState>,
-	app: AppHandle,
+    fs_state: State<'_, crate::fs_commands::FsState>,
+    app: AppHandle,
 ) -> Result<(), String> {
-	let workspace_path = get_workspace_path(&fs_state).await?;
+    let workspace_path = get_workspace_path(&fs_state).await?;
 
-	tokio::task::spawn_blocking(move || {
-		let repo = Repository::open(&workspace_path)
-			.map_err(|e| format!("Failed to open repo: {}", e))?;
+    tokio::task::spawn_blocking(move || {
+        let repo =
+            Repository::open(&workspace_path).map_err(|e| format!("Failed to open repo: {}", e))?;
 
-		if let Ok(head) = repo.head() {
-			if let Ok(obj) = head.peel(git2::ObjectType::Commit) {
-				repo.reset(&obj, ResetType::Mixed, None)
-					.map_err(|e| format!("Failed to unstage all: {}", e))?;
-			}
-		} else {
-			// No HEAD — clear the index entirely
-			let mut index = repo.index().map_err(|e| format!("Failed to get index: {}", e))?;
-			index.clear().map_err(|e| format!("Failed to clear index: {}", e))?;
-			index.write().map_err(|e| format!("Failed to write index: {}", e))?;
-		}
+        if let Ok(head) = repo.head() {
+            if let Ok(obj) = head.peel(git2::ObjectType::Commit) {
+                repo.reset(&obj, ResetType::Mixed, None)
+                    .map_err(|e| format!("Failed to unstage all: {}", e))?;
+            }
+        } else {
+            // No HEAD — clear the index entirely
+            let mut index = repo
+                .index()
+                .map_err(|e| format!("Failed to get index: {}", e))?;
+            index
+                .clear()
+                .map_err(|e| format!("Failed to clear index: {}", e))?;
+            index
+                .write()
+                .map_err(|e| format!("Failed to write index: {}", e))?;
+        }
 
-		emit_git_changes_updated(&app);
-		Ok(())
-	})
-	.await
-	.map_err(|e| format!("Task join error: {}", e))?
+        emit_git_changes_updated(&app);
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }
 
 /// Create a new local branch and check it out
 #[tauri::command]
 pub async fn git_create_branch(
-	fs_state: State<'_, crate::fs_commands::FsState>,
-	app: AppHandle,
-	branch_name: String,
+    fs_state: State<'_, crate::fs_commands::FsState>,
+    app: AppHandle,
+    branch_name: String,
 ) -> Result<(), String> {
-	let workspace_path = get_workspace_path(&fs_state).await?;
+    let workspace_path = get_workspace_path(&fs_state).await?;
 
-	tokio::task::spawn_blocking(move || {
-		cleanup_git_locks(&workspace_path);
+    tokio::task::spawn_blocking(move || {
+        cleanup_git_locks(&workspace_path);
 
-		// Validate branch name
-		let name = branch_name.trim();
-		if name.is_empty() {
-			return Err("Branch name cannot be empty".to_string());
-		}
-		if name.contains(' ') || name.contains("..") || name.contains('~')
-			|| name.contains('^') || name.contains(':') || name.contains('\\')
-			|| name.starts_with('-') || name.ends_with('/') || name.ends_with(".lock")
-			|| name.contains('\x00')
-		{
-			return Err(format!("Invalid branch name: '{}'", name));
-		}
+        // Validate branch name
+        let name = branch_name.trim();
+        if name.is_empty() {
+            return Err("Branch name cannot be empty".to_string());
+        }
+        if name.contains(' ')
+            || name.contains("..")
+            || name.contains('~')
+            || name.contains('^')
+            || name.contains(':')
+            || name.contains('\\')
+            || name.starts_with('-')
+            || name.ends_with('/')
+            || name.ends_with(".lock")
+            || name.contains('\x00')
+        {
+            return Err(format!("Invalid branch name: '{}'", name));
+        }
 
-		let repo = Repository::open(&workspace_path)
-			.map_err(|e| format!("Failed to open repo: {}", e))?;
+        let repo =
+            Repository::open(&workspace_path).map_err(|e| format!("Failed to open repo: {}", e))?;
 
-		// Get HEAD commit
-		let head = repo.head().map_err(|e| format!("Failed to get HEAD: {}", e))?;
-		let commit = head
-			.peel_to_commit()
-			.map_err(|e| format!("Failed to peel HEAD to commit: {}", e))?;
+        // Get HEAD commit
+        let head = repo
+            .head()
+            .map_err(|e| format!("Failed to get HEAD: {}", e))?;
+        let commit = head
+            .peel_to_commit()
+            .map_err(|e| format!("Failed to peel HEAD to commit: {}", e))?;
 
-		// Create branch (fails if it already exists)
-		repo.branch(name, &commit, false)
-			.map_err(|e| format!("Failed to create branch '{}': {}", name, e))?;
+        // Create branch (fails if it already exists)
+        repo.branch(name, &commit, false)
+            .map_err(|e| format!("Failed to create branch '{}': {}", name, e))?;
 
-		// Checkout the new branch
-		let refname = format!("refs/heads/{}", name);
-		repo.set_head(&refname)
-			.map_err(|e| format!("Failed to set HEAD to '{}': {}", name, e))?;
+        // Checkout the new branch
+        let refname = format!("refs/heads/{}", name);
+        repo.set_head(&refname)
+            .map_err(|e| format!("Failed to set HEAD to '{}': {}", name, e))?;
 
-		let obj = commit.as_object();
-		repo.checkout_tree(obj, None)
-			.map_err(|e| format!("Failed to checkout '{}': {}", name, e))?;
+        let obj = commit.as_object();
+        repo.checkout_tree(obj, None)
+            .map_err(|e| format!("Failed to checkout '{}': {}", name, e))?;
 
-		emit_git_changes_updated(&app);
-		Ok(())
-	})
-	.await
-	.map_err(|e| format!("Task join error: {}", e))?
+        emit_git_changes_updated(&app);
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,28 +1,55 @@
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::wildcard_imports,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::uninlined_format_args,
+    clippy::doc_markdown,
+    clippy::return_self_not_must_use,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_match_else,
+    clippy::if_not_else,
+    clippy::match_same_arms,
+    clippy::map_unwrap_or,
+    clippy::similar_names,
+    clippy::struct_excessive_bools,
+    // Tauri-specific: commands have AppHandle + State + many params
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    clippy::needless_pass_by_value,
+)]
+
 //! Solo Desktop Library
 //!
 //! This module provides the library interface for the Solo desktop application.
 
-mod commands;
-mod fs_commands;
 mod agent_commands;
-mod parse_commands;
 mod auth_commands;
+mod commands;
 mod embedding_commands;
-mod terminal_commands;
+mod fs_commands;
 mod git_commands;
+mod parse_commands;
+mod terminal_commands;
 mod worktree_commands;
 
-use fs_commands::FsState;
 use agent_commands::AgentState;
 use auth_commands::AuthState;
 use embedding_commands::EmbeddingState;
-use terminal_commands::TerminalState;
+use fs_commands::FsState;
 use git_commands::GitState;
-use worktree_commands::WorktreeState;
 use tauri::Emitter;
 #[cfg(target_os = "macos")]
 use tauri_plugin_decorum::WebviewWindowExt;
+use terminal_commands::TerminalState;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use worktree_commands::WorktreeState;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -84,8 +111,8 @@ pub fn run() {
             // macOS: position traffic lights and apply native vibrancy
             #[cfg(target_os = "macos")]
             {
-                use tauri::Manager;
                 use tauri::window::{Effect, EffectState, EffectsBuilder};
+                use tauri::Manager;
                 if let Some(window) = app.get_webview_window("main") {
                     let _ = window.set_traffic_lights_inset(13.0, 13.0);
                     let _ = window.set_effects(

--- a/apps/desktop/src-tauri/src/parse_commands.rs
+++ b/apps/desktop/src-tauri/src/parse_commands.rs
@@ -109,11 +109,14 @@ pub async fn parse_file(
             path: path.clone(),
         })?;
 
-        let workspace_canonical = workspace_path.canonicalize().map_err(|e| FileOperationError {
-            code: FileErrorCode::IoError,
-            message: e.to_string(),
-            path: path.clone(),
-        })?;
+        let workspace_canonical =
+            workspace_path
+                .canonicalize()
+                .map_err(|e| FileOperationError {
+                    code: FileErrorCode::IoError,
+                    message: e.to_string(),
+                    path: path.clone(),
+                })?;
 
         if !canonical.starts_with(&workspace_canonical) {
             return Err(FileOperationError {

--- a/apps/desktop/src-tauri/src/terminal_commands.rs
+++ b/apps/desktop/src-tauri/src/terminal_commands.rs
@@ -276,7 +276,10 @@ pub fn spawn_pty(
         .to_string();
 
     info!(id = %id, shell = %shell_path, cwd = %working_dir.display(), "Spawned PTY");
-    Ok(SpawnResult { id, shell: shell_name })
+    Ok(SpawnResult {
+        id,
+        shell: shell_name,
+    })
 }
 
 /// Emit accumulated terminal data as a single IPC event.
@@ -420,11 +423,7 @@ fn split_utf8(bytes: &[u8]) -> (&[u8], &[u8]) {
 
 /// Write data to a terminal's stdin.
 #[tauri::command]
-pub fn write_pty(
-    id: String,
-    data: String,
-    state: State<'_, TerminalState>,
-) -> Result<(), String> {
+pub fn write_pty(id: String, data: String, state: State<'_, TerminalState>) -> Result<(), String> {
     let terminals = state
         .terminals
         .read()
@@ -483,10 +482,7 @@ pub fn resize_pty(
 
 /// Kill a terminal process and remove it from state.
 #[tauri::command]
-pub fn kill_pty(
-    id: String,
-    state: State<'_, TerminalState>,
-) -> Result<(), String> {
+pub fn kill_pty(id: String, state: State<'_, TerminalState>) -> Result<(), String> {
     let mut terminals = state
         .terminals
         .write()

--- a/apps/desktop/src-tauri/src/worktree_commands.rs
+++ b/apps/desktop/src-tauri/src/worktree_commands.rs
@@ -3,7 +3,9 @@
 //! This module contains all git worktree related IPC commands.
 
 use solo_git::WorktreeManager;
-use solo_protocol::{BackendEvent, CreateWorktreeRequest, RemoveWorktreeRequest, WorktreeInfo, WorktreeSetupConfig};
+use solo_protocol::{
+    BackendEvent, CreateWorktreeRequest, RemoveWorktreeRequest, WorktreeInfo, WorktreeSetupConfig,
+};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use tauri::{AppHandle, Emitter, State};
@@ -37,10 +39,7 @@ impl Default for WorktreeState {
 }
 
 /// Get or create a WorktreeManager for the current workspace.
-async fn get_manager(
-    wt_state: &WorktreeState,
-    fs_state: &FsState,
-) -> Result<PathBuf, String> {
+async fn get_manager(wt_state: &WorktreeState, fs_state: &FsState) -> Result<PathBuf, String> {
     let workspace = fs_state.workspace_root.read().await;
     let repo_path = workspace
         .as_ref()
@@ -49,8 +48,7 @@ async fn get_manager(
 
     let mut managers = wt_state.managers.write().await;
     if !managers.contains_key(&repo_path) {
-        let manager = WorktreeManager::new(repo_path.clone())
-            .map_err(|e| e.to_string())?;
+        let manager = WorktreeManager::new(&repo_path).map_err(|e| e.to_string())?;
         managers.insert(repo_path.clone(), manager);
     }
 
@@ -85,20 +83,26 @@ pub async fn worktree_create(
     let repo_path = get_manager(&wt_state, &fs_state).await?;
 
     // Emit progress
-    let _ = app.emit("backend-event", &BackendEvent::WorktreeProgress {
-        worktree_id: request.branch.clone(),
-        message: format!("Creating worktree for branch '{}'...", request.branch),
-    });
+    let _ = app.emit(
+        "backend-event",
+        &BackendEvent::WorktreeProgress {
+            worktree_id: request.branch.clone(),
+            message: format!("Creating worktree for branch '{}'...", request.branch),
+        },
+    );
 
     let managers = wt_state.managers.read().await;
     let manager = managers.get(&repo_path).unwrap();
 
     match manager.create(&request) {
         Ok(info) => {
-            let _ = app.emit("backend-event", &BackendEvent::WorktreeReady {
-                worktree_id: info.id.clone(),
-                info: info.clone(),
-            });
+            let _ = app.emit(
+                "backend-event",
+                &BackendEvent::WorktreeReady {
+                    worktree_id: info.id.clone(),
+                    info: info.clone(),
+                },
+            );
 
             // Run setup commands in background if configured
             let setup_commands = manager.get_setup_commands().unwrap_or_default();
@@ -109,13 +113,16 @@ pub async fn worktree_create(
 
                 tokio::spawn(async move {
                     for cmd in &setup_commands {
-                        let _ = app_clone.emit("backend-event", &BackendEvent::WorktreeSetupProgress {
-                            worktree_id: wt_id.clone(),
-                            command: cmd.clone(),
-                            output: format!("Running: {}", cmd),
-                            is_error: false,
-                            is_complete: false,
-                        });
+                        let _ = app_clone.emit(
+                            "backend-event",
+                            &BackendEvent::WorktreeSetupProgress {
+                                worktree_id: wt_id.clone(),
+                                command: cmd.clone(),
+                                output: format!("Running: {}", cmd),
+                                is_error: false,
+                                is_complete: false,
+                            },
+                        );
 
                         let output = tokio::process::Command::new("sh")
                             .args(["-c", cmd])
@@ -130,44 +137,60 @@ pub async fn worktree_create(
                                 let is_error = !out.status.success();
 
                                 if !stdout.is_empty() {
-                                    let _ = app_clone.emit("backend-event", &BackendEvent::WorktreeSetupProgress {
-                                        worktree_id: wt_id.clone(),
-                                        command: cmd.clone(),
-                                        output: stdout,
-                                        is_error: false,
-                                        is_complete: false,
-                                    });
+                                    let _ = app_clone.emit(
+                                        "backend-event",
+                                        &BackendEvent::WorktreeSetupProgress {
+                                            worktree_id: wt_id.clone(),
+                                            command: cmd.clone(),
+                                            output: stdout,
+                                            is_error: false,
+                                            is_complete: false,
+                                        },
+                                    );
                                 }
                                 if !stderr.is_empty() || is_error {
-                                    let _ = app_clone.emit("backend-event", &BackendEvent::WorktreeSetupProgress {
-                                        worktree_id: wt_id.clone(),
-                                        command: cmd.clone(),
-                                        output: if stderr.is_empty() { "Command failed".to_string() } else { stderr },
-                                        is_error,
-                                        is_complete: false,
-                                    });
+                                    let _ = app_clone.emit(
+                                        "backend-event",
+                                        &BackendEvent::WorktreeSetupProgress {
+                                            worktree_id: wt_id.clone(),
+                                            command: cmd.clone(),
+                                            output: if stderr.is_empty() {
+                                                "Command failed".to_string()
+                                            } else {
+                                                stderr
+                                            },
+                                            is_error,
+                                            is_complete: false,
+                                        },
+                                    );
                                 }
                             }
                             Err(e) => {
-                                let _ = app_clone.emit("backend-event", &BackendEvent::WorktreeSetupProgress {
-                                    worktree_id: wt_id.clone(),
-                                    command: cmd.clone(),
-                                    output: format!("Failed to run command: {}", e),
-                                    is_error: true,
-                                    is_complete: false,
-                                });
+                                let _ = app_clone.emit(
+                                    "backend-event",
+                                    &BackendEvent::WorktreeSetupProgress {
+                                        worktree_id: wt_id.clone(),
+                                        command: cmd.clone(),
+                                        output: format!("Failed to run command: {}", e),
+                                        is_error: true,
+                                        is_complete: false,
+                                    },
+                                );
                             }
                         }
                     }
 
                     // Signal all setup commands complete
-                    let _ = app_clone.emit("backend-event", &BackendEvent::WorktreeSetupProgress {
-                        worktree_id: wt_id,
-                        command: String::new(),
-                        output: "Setup complete".to_string(),
-                        is_error: false,
-                        is_complete: true,
-                    });
+                    let _ = app_clone.emit(
+                        "backend-event",
+                        &BackendEvent::WorktreeSetupProgress {
+                            worktree_id: wt_id,
+                            command: String::new(),
+                            output: "Setup complete".to_string(),
+                            is_error: false,
+                            is_complete: true,
+                        },
+                    );
                 });
             }
 
@@ -175,10 +198,13 @@ pub async fn worktree_create(
         }
         Err(e) => {
             let error_msg = e.to_string();
-            let _ = app.emit("backend-event", &BackendEvent::WorktreeError {
-                worktree_id: request.branch.clone(),
-                error: error_msg.clone(),
-            });
+            let _ = app.emit(
+                "backend-event",
+                &BackendEvent::WorktreeError {
+                    worktree_id: request.branch.clone(),
+                    error: error_msg.clone(),
+                },
+            );
             Err(error_msg)
         }
     }
@@ -198,7 +224,9 @@ pub async fn worktree_remove(
     let managers = wt_state.managers.read().await;
     let manager = managers.get(&repo_path).unwrap();
 
-    manager.remove(&request.id, request.force).map_err(|e| e.to_string())?;
+    manager
+        .remove(&request.id, request.force)
+        .map_err(|e| e.to_string())?;
 
     // If we removed the active worktree, reset to main
     let mut active = wt_state.active_worktree_id.write().await;
@@ -206,9 +234,12 @@ pub async fn worktree_remove(
         *active = None;
     }
 
-    let _ = app.emit("backend-event", &BackendEvent::WorktreeRemoved {
-        worktree_id: request.id,
-    });
+    let _ = app.emit(
+        "backend-event",
+        &BackendEvent::WorktreeRemoved {
+            worktree_id: request.id,
+        },
+    );
 
     Ok(())
 }
@@ -245,15 +276,14 @@ pub async fn worktree_set_active(
         let repo_path = get_manager(&wt_state, &fs_state).await?;
         let managers = wt_state.managers.read().await;
         let manager = managers.get(&repo_path).unwrap();
-        let wt_path = manager.worktree_path(wt_id)
+        let wt_path = manager
+            .worktree_path(wt_id)
             .ok_or_else(|| format!("Worktree not found: {}", wt_id))?;
         wt_path
     } else {
         // Reset to main workspace
         let workspace = fs_state.workspace_root.read().await;
-        workspace.as_ref()
-            .ok_or("No workspace root set")?
-            .clone()
+        workspace.as_ref().ok_or("No workspace root set")?.clone()
     };
 
     // Update active worktree ID
@@ -302,7 +332,9 @@ pub async fn worktree_lock(
     let managers = wt_state.managers.read().await;
     let manager = managers.get(&repo_path).unwrap();
 
-    manager.lock(&id, reason.as_deref()).map_err(|e| e.to_string())
+    manager
+        .lock(&id, reason.as_deref())
+        .map_err(|e| e.to_string())
 }
 
 /// Unlock a worktree
@@ -355,13 +387,18 @@ pub async fn worktree_set_setup_commands(
     wt_state: State<'_, WorktreeState>,
     fs_state: State<'_, FsState>,
 ) -> Result<(), String> {
-    info!(count = config.commands.len(), "Setting worktree setup commands");
+    info!(
+        count = config.commands.len(),
+        "Setting worktree setup commands"
+    );
 
     let repo_path = get_manager(&wt_state, &fs_state).await?;
     let managers = wt_state.managers.read().await;
     let manager = managers.get(&repo_path).unwrap();
 
-    manager.set_setup_commands(config.commands).map_err(|e| e.to_string())
+    manager
+        .set_setup_commands(config.commands)
+        .map_err(|e| e.to_string())
 }
 
 /// Get setup commands for new worktrees

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+cognitive-complexity-threshold = 30
+too-many-lines-threshold = 120
+too-many-arguments-threshold = 9
+single-char-binding-names-threshold = 5

--- a/crates/solo-agent/Cargo.toml
+++ b/crates/solo-agent/Cargo.toml
@@ -32,9 +32,6 @@ tracing = "0.1"
 # UUID for message/tool IDs
 uuid = { version = "1.0", features = ["v4"] }
 
-# Lazy static for model registry
-lazy_static = "1.5"
-
 # File globbing (used by tools)
 glob = "0.3"
 

--- a/crates/solo-agent/src/keychain.rs
+++ b/crates/solo-agent/src/keychain.rs
@@ -26,13 +26,10 @@ pub fn get_api_key(provider: &str) -> Result<Option<String>, String> {
     #[cfg(target_os = "macos")]
     {
         use security_framework::passwords::get_generic_password;
-        match get_generic_password(SERVICE_NAME, provider) {
-            Ok(bytes) => {
-                let key = String::from_utf8(bytes.to_vec())
-                    .map_err(|e| format!("Invalid UTF-8 in keychain: {}", e))?;
-                return Ok(Some(key));
-            }
-            Err(_) => {} // Fall through to env var
+        if let Ok(bytes) = get_generic_password(SERVICE_NAME, provider) {
+            let key = String::from_utf8(bytes.clone())
+                .map_err(|e| format!("Invalid UTF-8 in keychain: {}", e))?;
+            return Ok(Some(key));
         }
     }
 
@@ -58,7 +55,7 @@ pub fn clear_api_key(provider: &str) -> Result<(), String> {
     {
         use security_framework::passwords::delete_generic_password;
         match delete_generic_password(SERVICE_NAME, provider) {
-            Ok(_) => Ok(()),
+            Ok(()) => Ok(()),
             Err(e) => {
                 // If not found, that's fine
                 let msg = e.to_string();

--- a/crates/solo-agent/src/lib.rs
+++ b/crates/solo-agent/src/lib.rs
@@ -1,21 +1,47 @@
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::wildcard_imports,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::uninlined_format_args,
+    clippy::doc_markdown,
+    clippy::return_self_not_must_use,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_match_else,
+    clippy::if_not_else,
+    clippy::match_same_arms,
+    clippy::map_unwrap_or,
+    clippy::similar_names,
+    clippy::struct_excessive_bools
+)]
+
 //! Solo Agent - AI agent for Solo IDE
 //!
 //! This crate provides session management, tool infrastructure, and model
 //! definitions for the AI agent. All LLM communication is routed through the
 //! Solo server (Vercel AI SDK) via WebSocket — no direct API providers remain.
 
-pub mod provider;
-pub mod models;
-pub mod tools;
-pub mod system_prompt;
 pub mod keychain;
+pub mod models;
+pub mod provider;
+pub mod system_prompt;
+pub mod tools;
 
 // Re-export main types
-pub use provider::{ProviderType, ProviderConfig, ProviderError, ProviderResult, ToolDefinition};
+pub use keychain::{clear_api_key, get_api_key, has_api_key, set_api_key};
 pub use models::{AIModel, ModelCapabilities};
-pub use tools::{ToolRegistry, ToolExecutor, ToolError, ToolContext, SharedWorkspaceRoot, create_default_registry};
+pub use provider::{ProviderConfig, ProviderError, ProviderResult, ProviderType, ToolDefinition};
 pub use system_prompt::build_system_prompt;
-pub use keychain::{set_api_key, get_api_key, has_api_key, clear_api_key};
+pub use tools::{
+    create_default_registry, SharedWorkspaceRoot, ToolContext, ToolError, ToolExecutor,
+    ToolRegistry,
+};
 
 use solo_protocol::AgentMessage;
 use std::sync::Arc;
@@ -88,7 +114,10 @@ impl AgentManager {
     }
 
     /// Execute a tool call
-    pub async fn execute_tool(&self, tool_call: &solo_protocol::AgentToolCall) -> solo_protocol::ToolResult {
+    pub async fn execute_tool(
+        &self,
+        tool_call: &solo_protocol::AgentToolCall,
+    ) -> solo_protocol::ToolResult {
         let registry = self.tool_registry.read().await;
         registry.execute(tool_call).await
     }
@@ -104,11 +133,13 @@ impl AgentManager {
     }
 
     /// Create a new session
-    pub async fn create_session(&self, session_id: String, model: Option<String>) -> ProviderResult<()> {
+    pub async fn create_session(
+        &self,
+        session_id: String,
+        model: Option<String>,
+    ) -> ProviderResult<()> {
         let provider_type = self.get_active_provider().await;
-        let model = model.unwrap_or_else(|| {
-            models::get_default_model(provider_type).id.to_string()
-        });
+        let model = model.unwrap_or_else(|| models::get_default_model(provider_type).id.clone());
 
         let session = AgentSession::new(session_id.clone(), model);
         self.sessions.write().await.insert(session_id, session);
@@ -116,7 +147,11 @@ impl AgentManager {
     }
 
     /// Update the model for an existing session
-    pub async fn update_session_model(&self, session_id: &str, model: String) -> ProviderResult<()> {
+    pub async fn update_session_model(
+        &self,
+        session_id: &str,
+        model: String,
+    ) -> ProviderResult<()> {
         let mut sessions = self.sessions.write().await;
         let session = sessions
             .get_mut(session_id)
@@ -126,7 +161,11 @@ impl AgentManager {
     }
 
     /// Get a session by ID (returns read guard over all sessions)
-    pub async fn get_session(&self, session_id: &str) -> Option<tokio::sync::RwLockReadGuard<'_, std::collections::HashMap<String, AgentSession>>> {
+    pub async fn get_session(
+        &self,
+        session_id: &str,
+    ) -> Option<tokio::sync::RwLockReadGuard<'_, std::collections::HashMap<String, AgentSession>>>
+    {
         let sessions = self.sessions.read().await;
         if sessions.contains_key(session_id) {
             Some(sessions)
@@ -136,6 +175,7 @@ impl AgentManager {
     }
 
     /// Check if a provider has credentials (via keychain)
+    #[allow(clippy::unused_async)]
     pub async fn has_credentials(&self, provider_type: ProviderType) -> bool {
         has_api_key(provider_type.as_str()).unwrap_or(false)
     }

--- a/crates/solo-agent/src/models.rs
+++ b/crates/solo-agent/src/models.rs
@@ -1,5 +1,7 @@
 //! AI Model definitions and registry
 
+use std::sync::LazyLock;
+
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
@@ -56,9 +58,9 @@ pub struct AIModel {
     pub description: String,
 }
 
-// Since we can't use String in const, we use lazy_static to get models
-lazy_static::lazy_static! {
-    pub static ref ANTHROPIC_MODELS: Vec<AIModel> = vec![
+// Since we can't use String in const, we use LazyLock to get models
+pub static ANTHROPIC_MODELS: LazyLock<Vec<AIModel>> = LazyLock::new(|| {
+    vec![
         AIModel {
             id: "claude-sonnet-4-6".to_string(),
             display_name: "Claude Sonnet 4.6".to_string(),
@@ -107,9 +109,11 @@ lazy_static::lazy_static! {
             is_default: false,
             description: "Fast and efficient for simple tasks".to_string(),
         },
-    ];
+    ]
+});
 
-    pub static ref GEMINI_MODELS: Vec<AIModel> = vec![
+pub static GEMINI_MODELS: LazyLock<Vec<AIModel>> = LazyLock::new(|| {
+    vec![
         AIModel {
             id: "gemini-3-pro".to_string(),
             display_name: "Gemini 3 Pro".to_string(),
@@ -142,9 +146,11 @@ lazy_static::lazy_static! {
             is_default: false,
             description: "Fast multimodal model".to_string(),
         },
-    ];
+    ]
+});
 
-    pub static ref OPENAI_MODELS: Vec<AIModel> = vec![
+pub static OPENAI_MODELS: LazyLock<Vec<AIModel>> = LazyLock::new(|| {
+    vec![
         AIModel {
             id: "gpt-5.2-high".to_string(),
             display_name: "GPT-5.2 High".to_string(),
@@ -193,8 +199,8 @@ lazy_static::lazy_static! {
             is_default: false,
             description: "Fast and cost-effective".to_string(),
         },
-    ];
-}
+    ]
+});
 
 /// Get all models for a provider
 pub fn get_models_for_provider(provider: ProviderType) -> &'static [AIModel] {
@@ -208,10 +214,7 @@ pub fn get_models_for_provider(provider: ProviderType) -> &'static [AIModel] {
 /// Get default model for a provider
 pub fn get_default_model(provider: ProviderType) -> &'static AIModel {
     let models = get_models_for_provider(provider);
-    models
-        .iter()
-        .find(|m| m.is_default)
-        .unwrap_or(&models[0])
+    models.iter().find(|m| m.is_default).unwrap_or(&models[0])
 }
 
 /// Find a model by ID or alias

--- a/crates/solo-agent/src/provider.rs
+++ b/crates/solo-agent/src/provider.rs
@@ -43,6 +43,7 @@ impl ProviderType {
     }
 
     /// Parse from string
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
             "anthropic" | "claude" => Some(ProviderType::Anthropic),
@@ -170,8 +171,14 @@ mod tests {
 
     #[test]
     fn test_provider_type_parsing() {
-        assert_eq!(ProviderType::from_str("anthropic"), Some(ProviderType::Anthropic));
-        assert_eq!(ProviderType::from_str("claude"), Some(ProviderType::Anthropic));
+        assert_eq!(
+            ProviderType::from_str("anthropic"),
+            Some(ProviderType::Anthropic)
+        );
+        assert_eq!(
+            ProviderType::from_str("claude"),
+            Some(ProviderType::Anthropic)
+        );
         assert_eq!(ProviderType::from_str("openai"), Some(ProviderType::OpenAI));
         assert_eq!(ProviderType::from_str("gpt"), Some(ProviderType::OpenAI));
         assert_eq!(ProviderType::from_str("gemini"), Some(ProviderType::Gemini));

--- a/crates/solo-agent/src/system_prompt.rs
+++ b/crates/solo-agent/src/system_prompt.rs
@@ -3,6 +3,8 @@
 //! Generates a system prompt that describes available tools, workspace context,
 //! and behavioral guidelines.
 
+use std::fmt::Write;
+
 use crate::provider::ToolDefinition;
 
 /// Build a coding-agent system prompt from the current tool set and workspace info.
@@ -18,7 +20,11 @@ pub fn build_system_prompt(tools: &[ToolDefinition], workspace_root: &str) -> St
     );
 
     // ── Workspace context ────────────────────────────────────────────
-    prompt.push_str(&format!("## Workspace\n\nCurrent workspace root: `{}`\n\n", workspace_root));
+    let _ = write!(
+        prompt,
+        "## Workspace\n\nCurrent workspace root: `{}`\n\n",
+        workspace_root
+    );
 
     // ── Tool descriptions ────────────────────────────────────────────
     if !tools.is_empty() {
@@ -29,14 +35,14 @@ pub fn build_system_prompt(tools: &[ToolDefinition], workspace_root: &str) -> St
         );
 
         for tool in tools {
-            prompt.push_str(&format!("### `{}`\n", tool.name));
-            prompt.push_str(&format!("{}\n", tool.description));
+            let _ = writeln!(prompt, "### `{}`", tool.name);
+            let _ = writeln!(prompt, "{}", tool.description);
             if tool.needs_approval {
                 prompt.push_str("*Requires user approval before execution.*\n");
             }
             // Include a compact schema
             if let Ok(schema_str) = serde_json::to_string_pretty(&tool.input_schema) {
-                prompt.push_str(&format!("```json\n{}\n```\n", schema_str));
+                let _ = write!(prompt, "```json\n{}\n```\n", schema_str);
             }
             prompt.push('\n');
         }

--- a/crates/solo-agent/src/tools.rs
+++ b/crates/solo-agent/src/tools.rs
@@ -5,6 +5,7 @@
 //! and parallel tool execution.
 
 use std::collections::HashMap;
+use std::fmt::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -49,7 +50,10 @@ pub type ToolResult_ = Result<String, ToolError>;
 
 /// Validate that a path is safe for file operations.
 /// Resolves the path and checks it doesn't escape the allowed roots.
-fn validate_path(path_str: &str, workspace_root: Option<&Path>) -> Result<std::path::PathBuf, ToolError> {
+fn validate_path(
+    path_str: &str,
+    workspace_root: Option<&Path>,
+) -> Result<std::path::PathBuf, ToolError> {
     let path = Path::new(path_str);
 
     // Must be absolute
@@ -62,14 +66,13 @@ fn validate_path(path_str: &str, workspace_root: Option<&Path>) -> Result<std::p
     // Canonicalize to resolve symlinks and ../ components
     // Use the raw path if the file doesn't exist yet (for write operations)
     let canonical = if path.exists() {
-        path.canonicalize().map_err(|e| {
-            ToolError::PathViolation(format!("Failed to resolve path: {}", e))
-        })?
+        path.canonicalize()
+            .map_err(|e| ToolError::PathViolation(format!("Failed to resolve path: {}", e)))?
     } else {
         // For new files, canonicalize the parent directory
-        let parent = path.parent().ok_or_else(|| {
-            ToolError::PathViolation("Path has no parent directory".to_string())
-        })?;
+        let parent = path
+            .parent()
+            .ok_or_else(|| ToolError::PathViolation("Path has no parent directory".to_string()))?;
         if !parent.exists() {
             return Err(ToolError::PathViolation(format!(
                 "Parent directory does not exist: {}",
@@ -79,9 +82,10 @@ fn validate_path(path_str: &str, workspace_root: Option<&Path>) -> Result<std::p
         let canonical_parent = parent.canonicalize().map_err(|e| {
             ToolError::PathViolation(format!("Failed to resolve parent path: {}", e))
         })?;
-        canonical_parent.join(path.file_name().ok_or_else(|| {
-            ToolError::PathViolation("Path has no filename".to_string())
-        })?)
+        canonical_parent.join(
+            path.file_name()
+                .ok_or_else(|| ToolError::PathViolation("Path has no filename".to_string()))?,
+        )
     };
 
     // Block sensitive system paths
@@ -377,7 +381,10 @@ impl ToolExecutor for ReadFileTool {
         let content = tokio::fs::read_to_string(&path).await?;
 
         let offset = args.get("offset").and_then(|v| v.as_u64()).unwrap_or(1) as usize;
-        let limit = args.get("limit").and_then(|v| v.as_u64()).map(|v| v as usize);
+        let limit = args
+            .get("limit")
+            .and_then(|v| v.as_u64())
+            .map(|v| v as usize);
 
         // Add line numbers starting from offset (1-indexed)
         let lines: Vec<&str> = content.lines().collect();
@@ -388,7 +395,11 @@ impl ToolExecutor for ReadFileTool {
         };
 
         if start >= lines.len() {
-            return Ok(format!("(file has {} lines, offset {} is past end)", lines.len(), offset));
+            return Ok(format!(
+                "(file has {} lines, offset {} is past end)",
+                lines.len(),
+                offset
+            ));
         }
 
         let numbered: Vec<String> = lines[start..end]
@@ -458,7 +469,11 @@ impl ToolExecutor for WriteFileTool {
         let path = validate_path(path_str, ws_root.as_deref())?;
         drop(ws_root);
         tokio::fs::write(&path, content).await?;
-        Ok(format!("Successfully wrote {} bytes to {}", content.len(), path.display()))
+        Ok(format!(
+            "Successfully wrote {} bytes to {}",
+            content.len(),
+            path.display()
+        ))
     }
 
     fn definition(&self) -> ToolDefinition {
@@ -628,11 +643,7 @@ impl ToolExecutor for BashTool {
         }
 
         // Execute with timeout
-        let result = tokio::time::timeout(
-            Duration::from_millis(timeout_ms),
-            cmd.output(),
-        )
-        .await;
+        let result = tokio::time::timeout(Duration::from_millis(timeout_ms), cmd.output()).await;
 
         match result {
             Ok(Ok(output)) => {
@@ -711,9 +722,18 @@ impl ToolExecutor for GrepTool {
             .ok_or_else(|| ToolError::ExecutionFailed("Missing 'pattern' argument".to_string()))?;
 
         let path = args.get("path").and_then(|v| v.as_str()).unwrap_or(".");
-        let max_results = args.get("max_results").and_then(|v| v.as_u64()).unwrap_or(50);
-        let context_lines = args.get("context_lines").and_then(|v| v.as_u64()).unwrap_or(0);
-        let case_insensitive = args.get("case_insensitive").and_then(|v| v.as_bool()).unwrap_or(false);
+        let max_results = args
+            .get("max_results")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(50);
+        let context_lines = args
+            .get("context_lines")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let case_insensitive = args
+            .get("case_insensitive")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
         let file_type = args.get("file_type").and_then(|v| v.as_str());
 
         // Try ripgrep first (cached), fall back to grep
@@ -728,8 +748,10 @@ impl ToolExecutor for GrepTool {
         let output = if rg_available {
             let mut cmd = tokio::process::Command::new("rg");
             cmd.arg("--line-number")
-                .arg("--max-count").arg(max_results.to_string())
-                .arg("--context").arg(context_lines.to_string());
+                .arg("--max-count")
+                .arg(max_results.to_string())
+                .arg("--context")
+                .arg(context_lines.to_string());
             if case_insensitive {
                 cmd.arg("--ignore-case");
             }
@@ -740,8 +762,7 @@ impl ToolExecutor for GrepTool {
             cmd.output().await?
         } else {
             let mut cmd = tokio::process::Command::new("grep");
-            cmd.arg("-rn")
-                .arg("-m").arg(max_results.to_string());
+            cmd.arg("-rn").arg("-m").arg(max_results.to_string());
             if context_lines > 0 {
                 cmd.arg(format!("-C{}", context_lines));
             }
@@ -763,7 +784,8 @@ impl ToolExecutor for GrepTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "grep".to_string(),
-            description: "Search for a regex pattern in files. Uses ripgrep (rg) when available.".to_string(),
+            description: "Search for a regex pattern in files. Uses ripgrep (rg) when available."
+                .to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -833,10 +855,8 @@ impl EditTool {
         for (i, ca) in a.chars().enumerate() {
             curr[0] = i + 1;
             for (j, cb) in b.chars().enumerate() {
-                let cost = if ca == cb { 0 } else { 1 };
-                curr[j + 1] = (prev[j + 1] + 1)
-                    .min(curr[j] + 1)
-                    .min(prev[j] + cost);
+                let cost = usize::from(ca != cb);
+                curr[j + 1] = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
             }
             std::mem::swap(&mut prev, &mut curr);
         }
@@ -898,7 +918,10 @@ impl ToolExecutor for EditTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| ToolError::ExecutionFailed("Missing 'new_str' argument".to_string()))?;
 
-        let create_file = args.get("create_file").and_then(|v| v.as_bool()).unwrap_or(false);
+        let create_file = args
+            .get("create_file")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
 
         let ws_root = self.workspace_root.read().await;
         let path = validate_path(path_str, ws_root.as_deref())?;
@@ -917,7 +940,11 @@ impl ToolExecutor for EditTool {
                 tokio::fs::create_dir_all(parent).await?;
             }
             tokio::fs::write(&path, new_str).await?;
-            return Ok(format!("Created new file: {} ({} bytes)", path.display(), new_str.len()));
+            return Ok(format!(
+                "Created new file: {} ({} bytes)",
+                path.display(),
+                new_str.len()
+            ));
         }
 
         // Read existing file
@@ -938,17 +965,18 @@ impl ToolExecutor for EditTool {
                 );
 
                 if let Some((line, snippet, score)) = Self::find_closest_match(&content, old_str) {
-                    msg.push_str(&format!(
+                    let _ = write!(
+                        msg,
                         "\nDid you mean to match these similar lines (starting at line {})? (similarity: {:.0}%)\n\n",
                         line,
                         score * 100.0
-                    ));
+                    );
                     for (i, l) in snippet.lines().enumerate() {
-                        msg.push_str(&format!("    {} | {}\n", line + i, l));
+                        let _ = writeln!(msg, "    {} | {}", line + i, l);
                     }
                     msg.push_str("\nYour SEARCH block had:\n\n");
                     for l in old_str.lines() {
-                        msg.push_str(&format!("    {}\n", l));
+                        let _ = writeln!(msg, "    {}", l);
                     }
                 }
 
@@ -984,18 +1012,22 @@ impl ToolExecutor for EditTool {
                     let prefix = &content[..byte_offset];
                     let line_num = prefix.lines().count() + 1;
                     // Show a few lines of context
-                    let context_start = content[..byte_offset].rfind('\n').map(|p| p + 1).unwrap_or(0);
+                    let context_start = content[..byte_offset]
+                        .rfind('\n')
+                        .map(|p| p + 1)
+                        .unwrap_or(0);
                     let context_end = content[byte_offset..]
                         .find('\n')
                         .map(|p| byte_offset + p)
                         .unwrap_or(content.len());
                     let context_line = &content[context_start..context_end];
-                    msg.push_str(&format!(
-                        "  {}. Line {}: {}\n",
+                    let _ = writeln!(
+                        msg,
+                        "  {}. Line {}: {}",
                         idx + 1,
                         line_num,
                         context_line.chars().take(120).collect::<String>()
-                    ));
+                    );
                 }
                 Err(ToolError::ExecutionFailed(msg))
             }
@@ -1053,10 +1085,7 @@ impl ToolExecutor for GlobTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| ToolError::ExecutionFailed("Missing 'pattern' argument".to_string()))?;
 
-        let root = args
-            .get("path")
-            .and_then(|v| v.as_str())
-            .unwrap_or(".");
+        let root = args.get("path").and_then(|v| v.as_str()).unwrap_or(".");
 
         // Validate root path against workspace_root when set
         let ws_root_guard = self.workspace_root.read().await;
@@ -1093,9 +1122,8 @@ impl ToolExecutor for GlobTool {
             format!("{}/{}", root, pattern)
         };
 
-        let entries = glob::glob(&full_pattern).map_err(|e| {
-            ToolError::ExecutionFailed(format!("Invalid glob pattern: {}", e))
-        })?;
+        let entries = glob::glob(&full_pattern)
+            .map_err(|e| ToolError::ExecutionFailed(format!("Invalid glob pattern: {}", e)))?;
 
         let max_results = 200usize;
         let mut paths: Vec<String> = Vec::new();
@@ -1116,7 +1144,12 @@ impl ToolExecutor for GlobTool {
         } else {
             let mut result = paths.join("\n");
             if total > max_results {
-                result.push_str(&format!("\n\n... and {} more (showing first {})", total - max_results, max_results));
+                let _ = write!(
+                    result,
+                    "\n\n... and {} more (showing first {})",
+                    total - max_results,
+                    max_results
+                );
             }
             Ok(result)
         }
@@ -1290,7 +1323,9 @@ mod tests {
         // Create a temp file
         let dir = std::env::temp_dir();
         let file_path = dir.join("solo_test_read_lines.txt");
-        tokio::fs::write(&file_path, "line1\nline2\nline3\nline4\nline5\n").await.unwrap();
+        tokio::fs::write(&file_path, "line1\nline2\nline3\nline4\nline5\n")
+            .await
+            .unwrap();
 
         let tool = ReadFileTool::new(Arc::new(RwLock::new(None)));
         let args = serde_json::json!({ "path": file_path.to_str().unwrap() });
@@ -1299,7 +1334,8 @@ mod tests {
         assert!(result.contains("5 | line5"));
 
         // With offset and limit
-        let args = serde_json::json!({ "path": file_path.to_str().unwrap(), "offset": 2, "limit": 2 });
+        let args =
+            serde_json::json!({ "path": file_path.to_str().unwrap(), "offset": 2, "limit": 2 });
         let result = tool.execute(args, &ToolContext::new(None)).await.unwrap();
         assert!(result.contains("2 | line2"));
         assert!(result.contains("3 | line3"));
@@ -1313,7 +1349,9 @@ mod tests {
     async fn test_edit_tool_replace() {
         let dir = std::env::temp_dir();
         let file_path = dir.join("solo_test_edit.txt");
-        tokio::fs::write(&file_path, "fn main() {\n    println!(\"hello\");\n}\n").await.unwrap();
+        tokio::fs::write(&file_path, "fn main() {\n    println!(\"hello\");\n}\n")
+            .await
+            .unwrap();
 
         let tool = EditTool::new(Arc::new(RwLock::new(None)));
         let args = serde_json::json!({
@@ -1336,7 +1374,9 @@ mod tests {
     async fn test_edit_tool_no_match() {
         let dir = std::env::temp_dir();
         let file_path = dir.join("solo_test_edit_nomatch.txt");
-        tokio::fs::write(&file_path, "fn main() {\n    println!(\"hello\");\n}\n").await.unwrap();
+        tokio::fs::write(&file_path, "fn main() {\n    println!(\"hello\");\n}\n")
+            .await
+            .unwrap();
 
         let tool = EditTool::new(Arc::new(RwLock::new(None)));
         // Use a string that does NOT appear as a substring (typo in function name)

--- a/crates/solo-core/src/lib.rs
+++ b/crates/solo-core/src/lib.rs
@@ -1,3 +1,26 @@
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::wildcard_imports,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::uninlined_format_args,
+    clippy::doc_markdown,
+    clippy::return_self_not_must_use,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_match_else,
+    clippy::if_not_else,
+    clippy::match_same_arms,
+    clippy::map_unwrap_or,
+    clippy::similar_names,
+    clippy::struct_excessive_bools
+)]
+
 //! Solo Core - Core traits and types for the Solo IDE
 //!
 //! This crate provides the foundational abstractions used across
@@ -47,7 +70,7 @@ pub trait Service: Send + Sync {
 }
 
 /// Configuration for the Solo IDE
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct SoloConfig {
     /// Path to the workspace root
     pub workspace_root: Option<String>,
@@ -57,16 +80,6 @@ pub struct SoloConfig {
 
     /// AI agent configuration
     pub agent: AgentConfig,
-}
-
-impl Default for SoloConfig {
-    fn default() -> Self {
-        Self {
-            workspace_root: None,
-            terminal: TerminalConfig::default(),
-            agent: AgentConfig::default(),
-        }
-    }
 }
 
 /// Terminal configuration

--- a/crates/solo-embeddings/src/lib.rs
+++ b/crates/solo-embeddings/src/lib.rs
@@ -1,3 +1,26 @@
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::wildcard_imports,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::uninlined_format_args,
+    clippy::doc_markdown,
+    clippy::return_self_not_must_use,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_match_else,
+    clippy::if_not_else,
+    clippy::match_same_arms,
+    clippy::map_unwrap_or,
+    clippy::similar_names,
+    clippy::struct_excessive_bools
+)]
+
 //! Solo Embeddings - Vector embedding provider for semantic search
 //!
 //! This crate provides embedding functionality for semantic code search and RAG.
@@ -9,7 +32,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use thiserror::Error;
-use tracing::{debug, info, error};
+use tracing::{debug, error, info};
 
 // =============================================================================
 // Error Types
@@ -230,6 +253,7 @@ struct OpenAIEmbeddingData {
 
 #[derive(Debug, Deserialize)]
 struct OpenAIUsage {
+    #[allow(dead_code)]
     prompt_tokens: u32,
     total_tokens: u32,
 }
@@ -271,7 +295,9 @@ impl EmbeddingProvider for OpenAIEmbeddingProvider {
         let result: OpenAIEmbeddingResponse = response.json().await?;
 
         if result.data.is_empty() {
-            return Err(EmbeddingError::InvalidResponse("No embeddings returned".to_string()));
+            return Err(EmbeddingError::InvalidResponse(
+                "No embeddings returned".to_string(),
+            ));
         }
 
         info!(
@@ -281,7 +307,9 @@ impl EmbeddingProvider for OpenAIEmbeddingProvider {
             "Embedding generated"
         );
 
-        Ok(Embedding::new(result.data.into_iter().next().unwrap().embedding))
+        Ok(Embedding::new(
+            result.data.into_iter().next().unwrap().embedding,
+        ))
     }
 
     async fn embed_many(&self, texts: &[String]) -> EmbeddingResult<Vec<Embedding>> {
@@ -333,7 +361,10 @@ impl EmbeddingProvider for OpenAIEmbeddingProvider {
         let mut data = result.data;
         data.sort_by_key(|d| d.index);
 
-        Ok(data.into_iter().map(|d| Embedding::new(d.embedding)).collect())
+        Ok(data
+            .into_iter()
+            .map(|d| Embedding::new(d.embedding))
+            .collect())
     }
 
     fn dimensions(&self) -> usize {
@@ -401,7 +432,11 @@ impl<T: Clone + Send + Sync> EmbeddingIndex<T> {
             .collect();
 
         // Sort by score descending
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
 
         // Take top results
         results.truncate(limit);

--- a/crates/solo-fs/src/lib.rs
+++ b/crates/solo-fs/src/lib.rs
@@ -1,3 +1,26 @@
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::wildcard_imports,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::uninlined_format_args,
+    clippy::doc_markdown,
+    clippy::return_self_not_must_use,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_match_else,
+    clippy::if_not_else,
+    clippy::match_same_arms,
+    clippy::map_unwrap_or,
+    clippy::similar_names,
+    clippy::struct_excessive_bools
+)]
+
 //! Solo File System - File operations and watching for Solo IDE
 //!
 //! This crate provides file system functionality for the Solo IDE, including:

--- a/crates/solo-fs/src/operations.rs
+++ b/crates/solo-fs/src/operations.rs
@@ -26,17 +26,17 @@ pub fn validate_path(path: &Path, workspace_root: &Path) -> FsResult<std::path::
             .map_err(|e| FsError::from_io_error(e, &path.display().to_string()))?
     } else {
         // For new files, canonicalize the parent and append the filename
-        let parent = path.parent().ok_or_else(|| {
-            FsError::InvalidPath("Path has no parent directory".to_string())
-        })?;
+        let parent = path
+            .parent()
+            .ok_or_else(|| FsError::InvalidPath("Path has no parent directory".to_string()))?;
 
         let parent_canonical = parent
             .canonicalize()
             .map_err(|e| FsError::from_io_error(e, &parent.display().to_string()))?;
 
-        let filename = path.file_name().ok_or_else(|| {
-            FsError::InvalidPath("Path has no filename".to_string())
-        })?;
+        let filename = path
+            .file_name()
+            .ok_or_else(|| FsError::InvalidPath("Path has no filename".to_string()))?;
 
         parent_canonical.join(filename)
     };
@@ -133,9 +133,9 @@ pub fn create_file(path: &Path, content: Option<&str>, workspace_root: &Path) ->
 /// * `workspace_root` - Workspace root for path validation
 pub fn create_directory(path: &Path, workspace_root: &Path) -> FsResult<()> {
     // For new directories, validate the parent path
-    let parent = path.parent().ok_or_else(|| {
-        FsError::InvalidPath("Path has no parent directory".to_string())
-    })?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| FsError::InvalidPath("Path has no parent directory".to_string()))?;
 
     // Validate parent exists and is within workspace
     let _ = validate_path(parent, workspace_root)?;
@@ -151,8 +151,7 @@ pub fn create_directory(path: &Path, workspace_root: &Path) -> FsResult<()> {
 
     info!(path = %path.display(), "Creating directory");
 
-    fs::create_dir_all(path)
-        .map_err(|e| FsError::from_io_error(e, &path.display().to_string()))?;
+    fs::create_dir_all(path).map_err(|e| FsError::from_io_error(e, &path.display().to_string()))?;
 
     Ok(())
 }
@@ -393,8 +392,11 @@ mod tests {
         fs::write(temp.path().join("outside.txt"), "secret").unwrap();
 
         let result = validate_path(&malicious_path, &workspace);
-        assert!(matches!(result, Err(FsError::PathOutsideWorkspace(_))),
-            "Expected PathOutsideWorkspace error, got {:?}", result);
+        assert!(
+            matches!(result, Err(FsError::PathOutsideWorkspace(_))),
+            "Expected PathOutsideWorkspace error, got {:?}",
+            result
+        );
     }
 
     #[test]

--- a/crates/solo-fs/src/tree.rs
+++ b/crates/solo-fs/src/tree.rs
@@ -110,26 +110,24 @@ fn read_directory_children(path: &Path, remaining_depth: u32) -> FsResult<Vec<Fi
     // WHY: read_dir returns an iterator, not a vector
     // This is memory-efficient for large directories
     // DOCS: https://doc.rust-lang.org/std/fs/fn.read_dir.html
-    let entries = fs::read_dir(path).map_err(|e| FsError::from_io_error(e, &path.display().to_string()))?;
+    let entries =
+        fs::read_dir(path).map_err(|e| FsError::from_io_error(e, &path.display().to_string()))?;
 
     let mut children: Vec<FileTreeEntry> = Vec::new();
 
     for entry in entries {
         // WHY: Each entry in the iterator is a Result, so we need to handle errors
         // This handles cases like permission denied on individual files
-        let entry = entry.map_err(|e| FsError::Io(e))?;
+        let entry = entry.map_err(FsError::Io)?;
         let entry_path = entry.path();
 
         // WHY: metadata() gives us file type, size, and modification time
         // DOCS: https://doc.rust-lang.org/std/fs/struct.Metadata.html
-        let metadata = entry.metadata().map_err(|e| FsError::Io(e))?;
+        let metadata = entry.metadata().map_err(FsError::Io)?;
 
         // WHY: OsStr -> String conversion needed for JSON serialization
         // to_string_lossy() replaces invalid UTF-8 with replacement characters
-        let name = entry
-            .file_name()
-            .to_string_lossy()
-            .to_string();
+        let name = entry.file_name().to_string_lossy().to_string();
 
         let path_str = entry_path.display().to_string();
         let is_dir = metadata.is_dir();
@@ -164,7 +162,7 @@ fn read_directory_children(path: &Path, remaining_depth: u32) -> FsResult<Vec<Fi
             // DOCS: https://doc.rust-lang.org/std/time/struct.SystemTime.html
             let modified = metadata
                 .modified()
-                .ok()  // Ignore errors (not all filesystems support this)
+                .ok() // Ignore errors (not all filesystems support this)
                 .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
                 .map(|d| d.as_secs());
             (size, modified)
@@ -187,7 +185,7 @@ fn read_directory_children(path: &Path, remaining_depth: u32) -> FsResult<Vec<Fi
     // DOCS: https://doc.rust-lang.org/std/vec/struct.Vec.html#method.sort_by
     children.sort_by(|a, b| {
         match (a.is_dir, b.is_dir) {
-            (true, false) => std::cmp::Ordering::Less,    // dirs before files
+            (true, false) => std::cmp::Ordering::Less, // dirs before files
             (false, true) => std::cmp::Ordering::Greater, // files after dirs
             _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()), // alphabetical
         }
@@ -198,8 +196,8 @@ fn read_directory_children(path: &Path, remaining_depth: u32) -> FsResult<Vec<Fi
 
 /// Get file metadata (size and modified time)
 pub fn get_file_metadata(path: &Path) -> FsResult<FileMetadata> {
-    let metadata = fs::metadata(path)
-        .map_err(|e| FsError::from_io_error(e, &path.display().to_string()))?;
+    let metadata =
+        fs::metadata(path).map_err(|e| FsError::from_io_error(e, &path.display().to_string()))?;
 
     let modified = metadata
         .modified()
@@ -259,7 +257,7 @@ pub struct FileMetadata {
 /// };
 /// let result = count_entries_with_config(path, config)?;
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct CountConfig {
     /// Maximum number of entries to count before stopping.
     /// This prevents counting millions of files in huge directories.
@@ -602,9 +600,16 @@ mod tests {
         let result = count_entries_with_config(temp.path(), config).unwrap();
 
         // Should stop at or near 50
-        assert!(result.count <= 51, "Expected ~50 entries, got {}", result.count);
+        assert!(
+            result.count <= 51,
+            "Expected ~50 entries, got {}",
+            result.count
+        );
         assert!(!result.is_exact, "Expected is_exact to be false");
-        assert!(result.truncation_reason.is_some(), "Expected truncation reason");
+        assert!(
+            result.truncation_reason.is_some(),
+            "Expected truncation reason"
+        );
     }
 
     #[test]
@@ -637,7 +642,8 @@ mod tests {
             respect_gitignore: false,
             ..CountConfig::default()
         };
-        let result_without = count_entries_with_config(temp.path(), config_without_gitignore).unwrap();
+        let result_without =
+            count_entries_with_config(temp.path(), config_without_gitignore).unwrap();
 
         // The count without gitignore should be higher (includes ignored/ and its contents)
         assert!(
@@ -685,7 +691,11 @@ mod tests {
         let result = count_entries_with_config(temp.path(), CountConfig::default()).unwrap();
 
         // Empty directory should have count of 0 or 1 (depending on whether root is counted)
-        assert!(result.count <= 1, "Expected 0 or 1 for empty dir, got {}", result.count);
+        assert!(
+            result.count <= 1,
+            "Expected 0 or 1 for empty dir, got {}",
+            result.count
+        );
         assert!(result.is_exact, "Expected exact count for empty directory");
     }
 

--- a/crates/solo-fs/src/watcher.rs
+++ b/crates/solo-fs/src/watcher.rs
@@ -105,25 +105,22 @@ impl FileWatcher {
 
             // Start the debouncing task
             tokio::spawn(async move {
-                let mut pending_events: HashMap<PathBuf, (FileEventType, Instant, Option<PathBuf>)> =
-                    HashMap::new();
+                let mut pending_events: HashMap<
+                    PathBuf,
+                    (FileEventType, Instant, Option<PathBuf>),
+                > = HashMap::new();
 
                 loop {
                     // Check for new events with timeout
-                    let timeout = tokio::time::timeout(
-                        Duration::from_millis(50),
-                        rx.recv(),
-                    )
-                    .await;
+                    let timeout = tokio::time::timeout(Duration::from_millis(50), rx.recv()).await;
 
                     match timeout {
                         Ok(Some(event)) => {
                             // Process the event
-                            if let Some((path, event_type, new_path)) = process_notify_event(&event) {
-                                pending_events.insert(
-                                    path.clone(),
-                                    (event_type, Instant::now(), new_path),
-                                );
+                            if let Some((path, event_type, new_path)) = process_notify_event(&event)
+                            {
+                                pending_events
+                                    .insert(path.clone(), (event_type, Instant::now(), new_path));
                             }
                         }
                         Ok(None) => {
@@ -239,7 +236,14 @@ impl Default for FileWatcher {
 
 /// Check if a path contains any of the ignored directory names as a component
 fn should_ignore_path(path: &Path) -> bool {
-    const IGNORED_DIRS: &[&str] = &[".git", "node_modules", "target", ".next", "dist", "__pycache__"];
+    const IGNORED_DIRS: &[&str] = &[
+        ".git",
+        "node_modules",
+        "target",
+        ".next",
+        "dist",
+        "__pycache__",
+    ];
 
     for component in path.components() {
         if let std::path::Component::Normal(name) = component {
@@ -341,8 +345,10 @@ mod tests {
         let event = result.unwrap().unwrap();
         // Note: On macOS FSEvents, file creation may be reported as Created or Modified
         assert!(
-            event.event_type == FileEventType::Created || event.event_type == FileEventType::Modified,
-            "Expected Created or Modified event, got {:?}", event.event_type
+            event.event_type == FileEventType::Created
+                || event.event_type == FileEventType::Modified,
+            "Expected Created or Modified event, got {:?}",
+            event.event_type
         );
     }
 

--- a/crates/solo-git/src/lib.rs
+++ b/crates/solo-git/src/lib.rs
@@ -1,3 +1,26 @@
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::wildcard_imports,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::uninlined_format_args,
+    clippy::doc_markdown,
+    clippy::return_self_not_must_use,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_match_else,
+    clippy::if_not_else,
+    clippy::match_same_arms,
+    clippy::map_unwrap_or,
+    clippy::similar_names,
+    clippy::struct_excessive_bools
+)]
+
 //! Solo Git — Git operations for Solo IDE
 //!
 //! Provides worktree management using `git2` (libgit2) for core operations
@@ -27,16 +50,16 @@ pub struct WorktreeManager {
 
 impl WorktreeManager {
     /// Create a new WorktreeManager for a repository path.
-    pub fn new(repo_path: PathBuf) -> Result<Self, GitError> {
+    pub fn new(repo_path: &Path) -> Result<Self, GitError> {
         // Validate that the path is a git repo by opening it
-        let repo = git2::Repository::open(&repo_path)
+        let repo = git2::Repository::open(repo_path)
             .map_err(|_| GitError::RepoNotFound(repo_path.display().to_string()))?;
 
         // Use the workdir or the repo path itself
         let actual_repo_path = repo
             .workdir()
             .map(|p| p.to_path_buf())
-            .unwrap_or_else(|| repo_path.clone());
+            .unwrap_or_else(|| repo_path.to_path_buf());
 
         let worktrees_dir = config::worktrees_base_dir(&actual_repo_path)?;
         let config_path = config::config_path(&actual_repo_path)?;
@@ -64,18 +87,16 @@ impl WorktreeManager {
                 .map(|oid| oid.to_string())
                 .unwrap_or_default();
 
-            let branch = repo
-                .head()
-                .ok()
-                .and_then(|r| {
-                    if r.is_branch() {
-                        r.shorthand().map(|s| s.to_string())
-                    } else {
-                        None
-                    }
-                });
+            let branch = repo.head().ok().and_then(|r| {
+                if r.is_branch() {
+                    r.shorthand().map(|s| s.to_string())
+                } else {
+                    None
+                }
+            });
 
-            let is_dirty = repo.statuses(None)
+            let is_dirty = repo
+                .statuses(None)
                 .map(|s| s.iter().any(|e| e.status() != git2::Status::CURRENT))
                 .unwrap_or(false);
 
@@ -101,29 +122,41 @@ impl WorktreeManager {
                     let wt_path = wt.path().to_path_buf();
 
                     // Open the worktree repo for HEAD info
-                    let (head_sha, branch, is_dirty) = if let Ok(wt_repo) = git2::Repository::open(&wt_path) {
-                        let sha = wt_repo.head().ok()
-                            .and_then(|r| r.target())
-                            .map(|oid| oid.to_string())
-                            .unwrap_or_default();
-                        let br = wt_repo.head().ok()
-                            .and_then(|r| {
-                                if r.is_branch() { r.shorthand().map(|s| s.to_string()) } else { None }
+                    let (head_sha, branch, is_dirty) =
+                        if let Ok(wt_repo) = git2::Repository::open(&wt_path) {
+                            let sha = wt_repo
+                                .head()
+                                .ok()
+                                .and_then(|r| r.target())
+                                .map(|oid| oid.to_string())
+                                .unwrap_or_default();
+                            let br = wt_repo.head().ok().and_then(|r| {
+                                if r.is_branch() {
+                                    r.shorthand().map(|s| s.to_string())
+                                } else {
+                                    None
+                                }
                             });
-                        let dirty = wt_repo.statuses(None)
-                            .map(|s| s.iter().any(|e| e.status() != git2::Status::CURRENT))
-                            .unwrap_or(false);
-                        (sha, br, dirty)
-                    } else {
-                        (String::new(), None, false)
-                    };
+                            let dirty = wt_repo
+                                .statuses(None)
+                                .map(|s| s.iter().any(|e| e.status() != git2::Status::CURRENT))
+                                .unwrap_or(false);
+                            (sha, br, dirty)
+                        } else {
+                            (String::new(), None, false)
+                        };
 
                     // Merge metadata from config
-                    let meta = config.worktrees.values()
+                    let meta = config
+                        .worktrees
+                        .values()
                         .find(|m| m.path == wt_path.display().to_string());
 
-                    let id = meta.map(|m| m.id.clone()).unwrap_or_else(|| name.to_string());
-                    let is_locked = wt.is_locked()
+                    let id = meta
+                        .map(|m| m.id.clone())
+                        .unwrap_or_else(|| name.to_string());
+                    let is_locked = wt
+                        .is_locked()
                         .map(|status| matches!(status, git2::WorktreeLockStatus::Locked(_)))
                         .unwrap_or(false);
                     let lock_reason = meta.and_then(|m| m.lock_reason.clone());
@@ -179,32 +212,44 @@ impl WorktreeManager {
             let base_commit = base_obj.peel_to_commit()?;
 
             // Check if branch already exists
-            if repo.find_branch(&request.branch, git2::BranchType::Local).is_ok() {
+            if repo
+                .find_branch(&request.branch, git2::BranchType::Local)
+                .is_ok()
+            {
                 return Err(GitError::BranchAlreadyExists(request.branch.clone()));
             }
 
             let branch = repo.branch(&request.branch, &base_commit, false)?;
             let branch_ref = branch.into_reference();
-            let ref_name = branch_ref.name()
+            let ref_name = branch_ref
+                .name()
                 .ok_or_else(|| GitError::Config("Invalid branch reference name".to_string()))?;
 
             repo.worktree(
                 &wt_id,
                 &wt_path,
-                Some(git2::WorktreeAddOptions::new().reference(Some(&repo.find_reference(ref_name)?))),
+                Some(
+                    git2::WorktreeAddOptions::new()
+                        .reference(Some(&repo.find_reference(ref_name)?)),
+                ),
             )?;
         } else {
             // Use existing branch
-            let branch = repo.find_branch(&request.branch, git2::BranchType::Local)
+            let branch = repo
+                .find_branch(&request.branch, git2::BranchType::Local)
                 .map_err(|_| GitError::BranchNotFound(request.branch.clone()))?;
             let branch_ref = branch.into_reference();
-            let ref_name = branch_ref.name()
+            let ref_name = branch_ref
+                .name()
                 .ok_or_else(|| GitError::Config("Invalid branch reference name".to_string()))?;
 
             repo.worktree(
                 &wt_id,
                 &wt_path,
-                Some(git2::WorktreeAddOptions::new().reference(Some(&repo.find_reference(ref_name)?))),
+                Some(
+                    git2::WorktreeAddOptions::new()
+                        .reference(Some(&repo.find_reference(ref_name)?)),
+                ),
             )?;
         }
 
@@ -215,11 +260,14 @@ impl WorktreeManager {
 
         // Get HEAD info from the new worktree
         let (head_sha, is_dirty) = if let Ok(wt_repo) = git2::Repository::open(&wt_path) {
-            let sha = wt_repo.head().ok()
+            let sha = wt_repo
+                .head()
+                .ok()
                 .and_then(|r| r.target())
                 .map(|oid| oid.to_string())
                 .unwrap_or_default();
-            let dirty = wt_repo.statuses(None)
+            let dirty = wt_repo
+                .statuses(None)
                 .map(|s| s.iter().any(|e| e.status() != git2::Status::CURRENT))
                 .unwrap_or(false);
             (sha, dirty)
@@ -263,7 +311,8 @@ impl WorktreeManager {
         }
 
         let mut config = WorktreeConfig::load(&self.config_path)?;
-        let meta = config.get(id)
+        let meta = config
+            .get(id)
             .ok_or_else(|| GitError::WorktreeNotFound(id.to_string()))?;
 
         if meta.is_locked && !force {
@@ -291,7 +340,8 @@ impl WorktreeManager {
                 warn!(id = %id, "Worktree directory already removed, cleaning up config");
             } else {
                 return Err(GitError::CommandFailed(format!(
-                    "git worktree remove failed: {}", stderr.trim()
+                    "git worktree remove failed: {}",
+                    stderr.trim()
                 )));
             }
         }
@@ -324,10 +374,12 @@ impl WorktreeManager {
         }
 
         let repo = git2::Repository::open(&self.repo_path)?;
-        let wt = repo.find_worktree(id)
+        let wt = repo
+            .find_worktree(id)
             .map_err(|_| GitError::WorktreeNotFound(id.to_string()))?;
 
-        let locked = wt.is_locked()
+        let locked = wt
+            .is_locked()
             .map(|status| matches!(status, git2::WorktreeLockStatus::Locked(_)))
             .unwrap_or(false);
         if locked {
@@ -355,10 +407,12 @@ impl WorktreeManager {
         }
 
         let repo = git2::Repository::open(&self.repo_path)?;
-        let wt = repo.find_worktree(id)
+        let wt = repo
+            .find_worktree(id)
             .map_err(|_| GitError::WorktreeNotFound(id.to_string()))?;
 
-        let locked = wt.is_locked()
+        let locked = wt
+            .is_locked()
             .map(|status| matches!(status, git2::WorktreeLockStatus::Locked(_)))
             .unwrap_or(false);
         if !locked {
@@ -435,7 +489,7 @@ impl WorktreeManager {
             } else if let Some(max_days) = max_age_days {
                 let age_secs = now.saturating_sub(meta.created_at);
                 let age_days = age_secs / 86400;
-                if age_days > max_days as u64 {
+                if age_days > u64::from(max_days) {
                     info!(id = %id, age_days, max_days, "Pruning stale worktree");
                     true
                 } else {
@@ -517,14 +571,14 @@ mod tests {
 
     #[test]
     fn test_new_validates_repo() {
-        let result = WorktreeManager::new(PathBuf::from("/nonexistent/path"));
+        let result = WorktreeManager::new(Path::new("/nonexistent/path"));
         assert!(result.is_err());
     }
 
     #[test]
     fn test_list_includes_main() {
         let (_dir, repo_path) = setup_test_repo();
-        let mgr = WorktreeManager::new(repo_path).unwrap();
+        let mgr = WorktreeManager::new(&repo_path).unwrap();
         let list = mgr.list().unwrap();
         assert_eq!(list.len(), 1);
         assert!(list[0].is_main);
@@ -534,7 +588,7 @@ mod tests {
     #[test]
     fn test_create_and_list() {
         let (_dir, repo_path) = setup_test_repo();
-        let mgr = WorktreeManager::new(repo_path).unwrap();
+        let mgr = WorktreeManager::new(&repo_path).unwrap();
 
         let req = CreateWorktreeRequest {
             branch: "feature-test".to_string(),
@@ -555,7 +609,7 @@ mod tests {
     #[test]
     fn test_create_and_remove() {
         let (_dir, repo_path) = setup_test_repo();
-        let mgr = WorktreeManager::new(repo_path).unwrap();
+        let mgr = WorktreeManager::new(&repo_path).unwrap();
 
         let req = CreateWorktreeRequest {
             branch: "feature-remove".to_string(),
@@ -578,7 +632,7 @@ mod tests {
     #[test]
     fn test_lock_unlock() {
         let (_dir, repo_path) = setup_test_repo();
-        let mgr = WorktreeManager::new(repo_path).unwrap();
+        let mgr = WorktreeManager::new(&repo_path).unwrap();
 
         let req = CreateWorktreeRequest {
             branch: "feature-lock".to_string(),
@@ -604,7 +658,7 @@ mod tests {
     #[test]
     fn test_cannot_remove_main() {
         let (_dir, repo_path) = setup_test_repo();
-        let mgr = WorktreeManager::new(repo_path).unwrap();
+        let mgr = WorktreeManager::new(&repo_path).unwrap();
         assert!(mgr.remove("main", false).is_err());
     }
 }

--- a/crates/solo-parse/src/lib.rs
+++ b/crates/solo-parse/src/lib.rs
@@ -1,3 +1,26 @@
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::wildcard_imports,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::uninlined_format_args,
+    clippy::doc_markdown,
+    clippy::return_self_not_must_use,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_match_else,
+    clippy::if_not_else,
+    clippy::match_same_arms,
+    clippy::map_unwrap_or,
+    clippy::similar_names,
+    clippy::struct_excessive_bools
+)]
+
 //! Solo Parse - Tree-sitter based code parsing for Solo IDE
 //!
 //! This crate provides:

--- a/crates/solo-parse/src/parser.rs
+++ b/crates/solo-parse/src/parser.rs
@@ -167,6 +167,7 @@ impl Parser {
         symbols
     }
 
+    #[allow(clippy::too_many_lines)]
     fn extract_rust_node(&self, node: &tree_sitter::Node, source: &str) -> Option<Symbol> {
         let kind = node.kind();
 
@@ -322,6 +323,7 @@ impl Parser {
         symbols
     }
 
+    #[allow(clippy::too_many_lines)]
     fn extract_ts_node_recursive(
         &self,
         node: &tree_sitter::Node,
@@ -333,17 +335,23 @@ impl Parser {
         match kind {
             "function_declaration" | "function" => {
                 if let Some(name_node) = node.child_by_field_name("name") {
-                    let symbol =
-                        Symbol::new(self.get_node_text(&name_node, source), SymbolKind::Function, Range::from_node(node))
-                            .with_selection_range(Range::from_node(&name_node));
+                    let symbol = Symbol::new(
+                        self.get_node_text(&name_node, source),
+                        SymbolKind::Function,
+                        Range::from_node(node),
+                    )
+                    .with_selection_range(Range::from_node(&name_node));
                     symbols.push(symbol);
                 }
             }
             "class_declaration" | "class" => {
                 if let Some(name_node) = node.child_by_field_name("name") {
-                    let mut symbol =
-                        Symbol::new(self.get_node_text(&name_node, source), SymbolKind::Class, Range::from_node(node))
-                            .with_selection_range(Range::from_node(&name_node));
+                    let mut symbol = Symbol::new(
+                        self.get_node_text(&name_node, source),
+                        SymbolKind::Class,
+                        Range::from_node(node),
+                    )
+                    .with_selection_range(Range::from_node(&name_node));
 
                     // Extract methods
                     if let Some(body) = node.child_by_field_name("body") {
@@ -402,9 +410,12 @@ impl Parser {
             }
             "enum_declaration" => {
                 if let Some(name_node) = node.child_by_field_name("name") {
-                    let symbol =
-                        Symbol::new(self.get_node_text(&name_node, source), SymbolKind::Enum, Range::from_node(node))
-                            .with_selection_range(Range::from_node(&name_node));
+                    let symbol = Symbol::new(
+                        self.get_node_text(&name_node, source),
+                        SymbolKind::Enum,
+                        Range::from_node(node),
+                    )
+                    .with_selection_range(Range::from_node(&name_node));
                     symbols.push(symbol);
                 }
             }
@@ -474,17 +485,23 @@ impl Parser {
         match kind {
             "function_definition" => {
                 if let Some(name_node) = node.child_by_field_name("name") {
-                    let symbol =
-                        Symbol::new(self.get_node_text(&name_node, source), SymbolKind::Function, Range::from_node(node))
-                            .with_selection_range(Range::from_node(&name_node));
+                    let symbol = Symbol::new(
+                        self.get_node_text(&name_node, source),
+                        SymbolKind::Function,
+                        Range::from_node(node),
+                    )
+                    .with_selection_range(Range::from_node(&name_node));
                     symbols.push(symbol);
                 }
             }
             "class_definition" => {
                 if let Some(name_node) = node.child_by_field_name("name") {
-                    let mut symbol =
-                        Symbol::new(self.get_node_text(&name_node, source), SymbolKind::Class, Range::from_node(node))
-                            .with_selection_range(Range::from_node(&name_node));
+                    let mut symbol = Symbol::new(
+                        self.get_node_text(&name_node, source),
+                        SymbolKind::Class,
+                        Range::from_node(node),
+                    )
+                    .with_selection_range(Range::from_node(&name_node));
 
                     // Extract methods
                     if let Some(body) = node.child_by_field_name("body") {
@@ -532,9 +549,12 @@ impl Parser {
                                 let key_text = self.get_node_text(&key, source);
                                 // Remove quotes
                                 let name = key_text.trim_matches('"');
-                                let symbol =
-                                    Symbol::new(name, SymbolKind::Property, Range::from_node(&child))
-                                        .with_selection_range(Range::from_node(&key));
+                                let symbol = Symbol::new(
+                                    name,
+                                    SymbolKind::Property,
+                                    Range::from_node(&child),
+                                )
+                                .with_selection_range(Range::from_node(&key));
                                 symbols.push(symbol);
                             }
                         }
@@ -547,6 +567,7 @@ impl Parser {
     }
 
     /// Extract symbols from HTML
+    #[allow(clippy::unused_self)]
     fn extract_html_symbols(&self, _root: &tree_sitter::Node, _source: &str) -> Vec<Symbol> {
         // HTML doesn't have meaningful "symbols" in the traditional sense
         Vec::new()
@@ -606,6 +627,7 @@ impl Parser {
         errors
     }
 
+    #[allow(clippy::self_only_used_in_recursion)]
     fn collect_errors_recursive(&self, node: &tree_sitter::Node, errors: &mut Vec<ParseError>) {
         if node.is_error() || node.is_missing() {
             errors.push(ParseError {
@@ -620,11 +642,12 @@ impl Parser {
 
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
-            self.collect_errors_recursive(&child, errors);
+            Self::collect_errors_recursive(self, &child, errors);
         }
     }
 
     /// Get the text content of a node
+    #[allow(clippy::unused_self)]
     fn get_node_text(&self, node: &tree_sitter::Node, source: &str) -> String {
         source[node.byte_range()].to_string()
     }

--- a/crates/solo-protocol/src/lib.rs
+++ b/crates/solo-protocol/src/lib.rs
@@ -1,3 +1,26 @@
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::wildcard_imports,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::uninlined_format_args,
+    clippy::doc_markdown,
+    clippy::return_self_not_must_use,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_match_else,
+    clippy::if_not_else,
+    clippy::match_same_arms,
+    clippy::map_unwrap_or,
+    clippy::similar_names,
+    clippy::struct_excessive_bools
+)]
+
 //! Solo Protocol - IPC message types for communication between Rust backend and TypeScript frontend
 //!
 //! This crate defines all message types used for Tauri IPC communication.
@@ -753,11 +776,17 @@ pub enum BackendEvent {
 
     /// Worktree operation progress
     #[serde(rename = "worktree:progress")]
-    WorktreeProgress { worktree_id: String, message: String },
+    WorktreeProgress {
+        worktree_id: String,
+        message: String,
+    },
 
     /// Worktree is ready
     #[serde(rename = "worktree:ready")]
-    WorktreeReady { worktree_id: String, info: WorktreeInfo },
+    WorktreeReady {
+        worktree_id: String,
+        info: WorktreeInfo,
+    },
 
     /// Worktree operation error
     #[serde(rename = "worktree:error")]
@@ -941,7 +970,11 @@ mod tests {
         assert_eq!(msg.content.len(), 2);
         // First is success
         match &msg.content[0] {
-            ContentBlock::ToolResult { tool_use_id, content, is_error } => {
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } => {
                 assert_eq!(tool_use_id, "tc-1");
                 assert_eq!(content, "result 1");
                 assert!(!is_error);
@@ -950,7 +983,11 @@ mod tests {
         }
         // Second is error
         match &msg.content[1] {
-            ContentBlock::ToolResult { tool_use_id, is_error, .. } => {
+            ContentBlock::ToolResult {
+                tool_use_id,
+                is_error,
+                ..
+            } => {
                 assert_eq!(tool_use_id, "tc-2");
                 assert!(is_error);
             }

--- a/docs/Claude/permissions.md
+++ b/docs/Claude/permissions.md
@@ -1,0 +1,258 @@
+> ## Documentation Index
+> Fetch the complete documentation index at: https://code.claude.com/docs/llms.txt
+> Use this file to discover all available pages before exploring further.
+
+# Configure permissions
+
+> Control what Claude Code can access and do with fine-grained permission rules, modes, and managed policies.
+
+Claude Code supports fine-grained permissions so that you can specify exactly what the agent is allowed to do and what it cannot. Permission settings can be checked into version control and distributed to all developers in your organization, as well as customized by individual developers.
+
+## Permission system
+
+Claude Code uses a tiered permission system to balance power and safety:
+
+| Tool type         | Example          | Approval required | "Yes, don't ask again" behavior               |
+| :---------------- | :--------------- | :---------------- | :-------------------------------------------- |
+| Read-only         | File reads, Grep | No                | N/A                                           |
+| Bash commands     | Shell execution  | Yes               | Permanently per project directory and command |
+| File modification | Edit/write files | Yes               | Until session end                             |
+
+## Manage permissions
+
+You can view and manage Claude Code's tool permissions with `/permissions`. This UI lists all permission rules and the settings.json file they are sourced from.
+
+* **Allow** rules let Claude Code use the specified tool without manual approval.
+* **Ask** rules prompt for confirmation whenever Claude Code tries to use the specified tool.
+* **Deny** rules prevent Claude Code from using the specified tool.
+
+Rules are evaluated in order: **deny -> ask -> allow**. The first matching rule wins, so deny rules always take precedence.
+
+## Permission modes
+
+Claude Code supports several permission modes that control how tools are approved. Set the `defaultMode` in your [settings files](/en/settings#settings-files):
+
+| Mode                | Description                                                                                                                                                                                                                                                  |
+| :------------------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default`           | Standard behavior: prompts for permission on first use of each tool                                                                                                                                                                                          |
+| `acceptEdits`       | Automatically accepts file edit permissions for the session                                                                                                                                                                                                  |
+| `plan`              | Plan Mode: Claude can analyze but not modify files or execute commands                                                                                                                                                                                       |
+| `delegate`          | Coordination-only mode for agent team leads. Restricts the lead to team management tools, so all implementation work happens through teammates. Only available when an agent team is active. See [delegate mode](/en/agent-teams#delegate-mode) for details. |
+| `dontAsk`           | Auto-denies tools unless pre-approved via `/permissions` or `permissions.allow` rules                                                                                                                                                                        |
+| `bypassPermissions` | Skips all permission prompts (requires safe environment, see warning below)                                                                                                                                                                                  |
+
+<Warning>
+  `bypassPermissions` mode disables all permission checks. Only use this in isolated environments like containers or VMs where Claude Code cannot cause damage. Administrators can prevent this mode by setting `disableBypassPermissionsMode` to `"disable"` in [managed settings](#managed-settings).
+</Warning>
+
+## Permission rule syntax
+
+Permission rules follow the format `Tool` or `Tool(specifier)`.
+
+### Match all uses of a tool
+
+To match all uses of a tool, use just the tool name without parentheses:
+
+| Rule       | Effect                         |
+| :--------- | :----------------------------- |
+| `Bash`     | Matches all Bash commands      |
+| `WebFetch` | Matches all web fetch requests |
+| `Read`     | Matches all file reads         |
+
+`Bash(*)` is equivalent to `Bash` and matches all Bash commands.
+
+### Use specifiers for fine-grained control
+
+Add a specifier in parentheses to match specific tool uses:
+
+| Rule                           | Effect                                                   |
+| :----------------------------- | :------------------------------------------------------- |
+| `Bash(npm run build)`          | Matches the exact command `npm run build`                |
+| `Read(./.env)`                 | Matches reading the `.env` file in the current directory |
+| `WebFetch(domain:example.com)` | Matches fetch requests to example.com                    |
+
+### Wildcard patterns
+
+Bash rules support glob patterns with `*`. Wildcards can appear at any position in the command. This configuration allows npm and git commit commands while blocking git push:
+
+```json  theme={null}
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run *)",
+      "Bash(git commit *)",
+      "Bash(git * main)",
+      "Bash(* --version)",
+      "Bash(* --help *)"
+    ],
+    "deny": [
+      "Bash(git push *)"
+    ]
+  }
+}
+```
+
+The space before `*` matters: `Bash(ls *)` matches `ls -la` but not `lsof`, while `Bash(ls*)` matches both. The legacy `:*` suffix syntax is equivalent to ` *` but is deprecated.
+
+## Tool-specific permission rules
+
+### Bash
+
+Bash permission rules support wildcard matching with `*`. Wildcards can appear at any position in the command, including at the beginning, middle, or end:
+
+* `Bash(npm run build)` matches the exact Bash command `npm run build`
+* `Bash(npm run test *)` matches Bash commands starting with `npm run test`
+* `Bash(npm *)` matches any command starting with `npm `
+* `Bash(* install)` matches any command ending with ` install`
+* `Bash(git * main)` matches commands like `git checkout main`, `git merge main`
+
+When `*` appears at the end with a space before it (like `Bash(ls *)`), it enforces a word boundary, requiring the prefix to be followed by a space or end-of-string. For example, `Bash(ls *)` matches `ls -la` but not `lsof`. In contrast, `Bash(ls*)` without a space matches both `ls -la` and `lsof` because there's no word boundary constraint.
+
+<Tip>
+  Claude Code is aware of shell operators (like `&&`) so a prefix match rule like `Bash(safe-cmd *)` won't give it permission to run the command `safe-cmd && other-cmd`.
+</Tip>
+
+<Warning>
+  Bash permission patterns that try to constrain command arguments are fragile. For example, `Bash(curl http://github.com/ *)` intends to restrict curl to GitHub URLs, but won't match variations like:
+
+  * Options before URL: `curl -X GET http://github.com/...`
+  * Different protocol: `curl https://github.com/...`
+  * Redirects: `curl -L http://bit.ly/xyz` (redirects to github)
+  * Variables: `URL=http://github.com && curl $URL`
+  * Extra spaces: `curl  http://github.com`
+
+  For more reliable URL filtering, consider:
+
+  * **Restrict Bash network tools**: use deny rules to block `curl`, `wget`, and similar commands, then use the WebFetch tool with `WebFetch(domain:github.com)` permission for allowed domains
+  * **Use PreToolUse hooks**: implement a hook that validates URLs in Bash commands and blocks disallowed domains
+  * Instructing Claude Code about your allowed curl patterns via CLAUDE.md
+
+  Note that using WebFetch alone does not prevent network access. If Bash is allowed, Claude can still use `curl`, `wget`, or other tools to reach any URL.
+</Warning>
+
+### Read and Edit
+
+`Edit` rules apply to all built-in tools that edit files. Claude makes a best-effort attempt to apply `Read` rules to all built-in tools that read files like Grep and Glob.
+
+Read and Edit rules both follow the [gitignore](https://git-scm.com/docs/gitignore) specification with four distinct pattern types:
+
+| Pattern            | Meaning                                | Example                          | Matches                            |
+| ------------------ | -------------------------------------- | -------------------------------- | ---------------------------------- |
+| `//path`           | **Absolute** path from filesystem root | `Read(//Users/alice/secrets/**)` | `/Users/alice/secrets/**`          |
+| `~/path`           | Path from **home** directory           | `Read(~/Documents/*.pdf)`        | `/Users/alice/Documents/*.pdf`     |
+| `/path`            | Path **relative to settings file**     | `Edit(/src/**/*.ts)`             | `<settings file path>/src/**/*.ts` |
+| `path` or `./path` | Path **relative to current directory** | `Read(*.env)`                    | `<cwd>/*.env`                      |
+
+<Warning>
+  A pattern like `/Users/alice/file` is NOT an absolute path. It's relative to your settings file. Use `//Users/alice/file` for absolute paths.
+</Warning>
+
+Examples:
+
+* `Edit(/docs/**)`: edits in `<project>/docs/` (NOT `/docs/`)
+* `Read(~/.zshrc)`: reads your home directory's `.zshrc`
+* `Edit(//tmp/scratch.txt)`: edits the absolute path `/tmp/scratch.txt`
+* `Read(src/**)`: reads from `<current-directory>/src/`
+
+<Note>
+  In gitignore patterns, `*` matches files in a single directory while `**` matches recursively across directories. To allow all file access, use just the tool name without parentheses: `Read`, `Edit`, or `Write`.
+</Note>
+
+### WebFetch
+
+* `WebFetch(domain:example.com)` matches fetch requests to example.com
+
+### MCP
+
+* `mcp__puppeteer` matches any tool provided by the `puppeteer` server (name configured in Claude Code)
+* `mcp__puppeteer__*` wildcard syntax that also matches all tools from the `puppeteer` server
+* `mcp__puppeteer__puppeteer_navigate` matches the `puppeteer_navigate` tool provided by the `puppeteer` server
+
+### Task (subagents)
+
+Use `Task(AgentName)` rules to control which [subagents](/en/sub-agents) Claude can use:
+
+* `Task(Explore)` matches the Explore subagent
+* `Task(Plan)` matches the Plan subagent
+* `Task(my-custom-agent)` matches a custom subagent named `my-custom-agent`
+
+Add these rules to the `deny` array in your settings or use the `--disallowedTools` CLI flag to disable specific agents. To disable the Explore agent:
+
+```json  theme={null}
+{
+  "permissions": {
+    "deny": ["Task(Explore)"]
+  }
+}
+```
+
+## Extend permissions with hooks
+
+[Claude Code hooks](/en/hooks-guide) provide a way to register custom shell commands to perform permission evaluation at runtime. When Claude Code makes a tool call, PreToolUse hooks run before the permission system, and the hook output can determine whether to approve or deny the tool call in place of the permission system.
+
+## Working directories
+
+By default, Claude has access to files in the directory where it was launched. You can extend this access:
+
+* **During startup**: use `--add-dir <path>` CLI argument
+* **During session**: use `/add-dir` command
+* **Persistent configuration**: add to `additionalDirectories` in [settings files](/en/settings#settings-files)
+
+Files in additional directories follow the same permission rules as the original working directory: they become readable without prompts, and file editing permissions follow the current permission mode.
+
+## How permissions interact with sandboxing
+
+Permissions and [sandboxing](/en/sandboxing) are complementary security layers:
+
+* **Permissions** control which tools Claude Code can use and which files or domains it can access. They apply to all tools (Bash, Read, Edit, WebFetch, MCP, and others).
+* **Sandboxing** provides OS-level enforcement that restricts the Bash tool's filesystem and network access. It applies only to Bash commands and their child processes.
+
+Use both for defense-in-depth:
+
+* Permission deny rules block Claude from even attempting to access restricted resources
+* Sandbox restrictions prevent Bash commands from reaching resources outside defined boundaries, even if a prompt injection bypasses Claude's decision-making
+* Filesystem restrictions in the sandbox use Read and Edit deny rules, not separate sandbox configuration
+* Network restrictions combine WebFetch permission rules with the sandbox's `allowedDomains` list
+
+## Managed settings
+
+For organizations that need centralized control over Claude Code configuration, administrators can deploy `managed-settings.json` files to system directories. These policy files follow the same format as regular settings files and cannot be overridden by user or project settings. For organizations without device management infrastructure, [server-managed settings](/en/server-managed-settings) provide an alternative that delivers configurations from Anthropic's servers.
+
+**Managed settings file locations**:
+
+* **macOS**: `/Library/Application Support/ClaudeCode/managed-settings.json`
+* **Linux and WSL**: `/etc/claude-code/managed-settings.json`
+* **Windows**: `C:\Program Files\ClaudeCode\managed-settings.json`
+
+<Note>
+  These are system-wide paths (not user home directories like `~/Library/...`) that require administrator privileges. They are designed to be deployed by IT administrators.
+</Note>
+
+### Managed-only settings
+
+Some settings are only effective in managed settings:
+
+| Setting                           | Description                                                                                                                                        |
+| :-------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `disableBypassPermissionsMode`    | Set to `"disable"` to prevent `bypassPermissions` mode and the `--dangerously-skip-permissions` flag                                               |
+| `allowManagedPermissionRulesOnly` | When `true`, prevents user and project settings from defining `allow`, `ask`, or `deny` permission rules. Only rules in managed settings apply     |
+| `allowManagedHooksOnly`           | When `true`, prevents loading of user, project, and plugin hooks. Only managed hooks and SDK hooks are allowed                                     |
+| `strictKnownMarketplaces`         | Controls which plugin marketplaces users can add. See [managed marketplace restrictions](/en/plugin-marketplaces#managed-marketplace-restrictions) |
+
+## Settings precedence
+
+Permission rules follow the same [settings precedence](/en/settings#settings-precedence) as all other Claude Code settings: managed settings have the highest precedence, followed by command line arguments, local project, shared project, and user settings.
+
+If a permission is allowed in user settings but denied in project settings, the project setting takes precedence and the permission is blocked.
+
+## Example configurations
+
+This [repository](https://github.com/anthropics/claude-code/tree/main/examples/settings) includes starter settings configurations for common deployment scenarios. Use these as starting points and adjust them to fit your needs.
+
+## See also
+
+* [Settings](/en/settings): complete configuration reference including the permission settings table
+* [Sandboxing](/en/sandboxing): OS-level filesystem and network isolation for Bash commands
+* [Authentication](/en/authentication): set up user access to Claude Code
+* [Security](/en/security): security safeguards and best practices
+* [Hooks](/en/hooks-guide): automate workflows and extend permission evaluation

--- a/docs/Claude/rust-ai-coding-infrastructure.md
+++ b/docs/Claude/rust-ai-coding-infrastructure.md
@@ -1,0 +1,150 @@
+# Building AI-Coding Infrastructure for a Rust IDE
+
+How we configured Solo IDE's Rust codebase so AI tools write idiomatic, correct code on the first try — inspired by [Coding Rust with Claude Code and Codex](https://tigran.tech/coding-rust-with-claude-code-and-codex/).
+
+---
+
+## The Insight: Rust's Compiler Is Your Best AI Reviewer
+
+The core thesis from Tigran's article resonated with our experience: **Rust's compiler acts as an automatic expert reviewer for every edit an AI tool makes.**
+
+In dynamic languages, AI-generated code can look perfectly reasonable, pass a quick review, and then fail in production. Rust eliminates entire classes of those failures. When Claude Code generates a function that violates ownership rules, the compiler responds with an exact error code (E0502), the precise source location, a clear explanation, and often a suggested fix. The AI parses this, applies the correction, and moves on — all without human intervention.
+
+This creates a tight feedback loop: generate code, run `cargo check`, parse errors, restructure, repeat. The AI handles the mechanical parts — which combination of `&`, `Arc`, `RwLock`, and lifetime annotations makes the borrow checker happy — while the developer focuses on architecture and logic.
+
+But this loop only works well if the AI knows **your** project's conventions. That's where infrastructure comes in.
+
+---
+
+## What We Built
+
+We took Tigran's recommendations and applied them systematically to Solo IDE, a Tauri 2 desktop application with 7 Rust crates. Here's what we implemented and why.
+
+### 1. A Comprehensive CLAUDE.md
+
+The original `CLAUDE.md` covered the basics — commands, monorepo layout, IPC patterns. But it was missing the Rust-specific guidance that AI tools need to write code that matches the project's style:
+
+**What we added:**
+
+- **Error Handling Patterns** — Solo uses a two-tier system: `thiserror` domain errors internally (`FsError`, `ProviderError`, `EmbeddingError`), converted to `Result<T, String>` at the Tauri IPC boundary. We documented this explicitly because without it, AI tools default to `anyhow` or raw `String` errors.
+
+- **Async Runtime Conventions** — Tokio 1.43 with Tauri managing the runtime. We documented the cancellation pattern (`watch::channel`), the tool approval pattern (`oneshot`), and the critical exception: PTY code uses `std::thread::spawn` because `portable-pty` is a blocking C library.
+
+- **Memory Management Rules** — The single most important rule: *never hold async lock guards across `.await`*. We documented when to use `tokio::sync::RwLock` vs `std::sync::RwLock`, and the `Arc<RwLock<T>>` pattern for spawned tasks.
+
+- **Serde Conventions** — Solo uses different serde tagging strategies for different types: internally tagged for `ContentBlock`, adjacently tagged for `BackendEvent`. Without documenting this, AI tools guess wrong and generate code that silently fails at deserialization.
+
+- **Testing Conventions** — Inline `#[cfg(test)]` modules only, `#[tokio::test]` for async, `tempfile::TempDir` for filesystem tests.
+
+- **Logging** — `tracing` with structured fields. Import only the macros you use — unused `tracing` imports now trigger clippy errors.
+
+- **AI Workflow** — An explicit verification checklist: `cargo check`, `cargo clippy -- -D warnings`, `cargo fmt --check`, `cargo test`. This gives AI tools a concrete definition of "done."
+
+### 2. Clippy Pedantic with Curated Allows
+
+Following Tigran's advice to "run clippy aggressively with all lints enabled," we enabled `clippy::pedantic` across all 7 crates. But pedantic out of the box generates hundreds of warnings in an established codebase. The key was **curating the allow list**.
+
+We categorized every pedantic lint into three buckets:
+
+1. **Keep enforced** — lints that catch real bugs or suggest genuine improvements (e.g., `redundant_closure`, `implicit_saturating_sub`, dead code warnings)
+2. **Allow globally** — lints that are purely style preferences and don't indicate bugs (e.g., `uninlined_format_args`, `single_match_else`, `doc_markdown`)
+3. **Allow per-crate** — lints specific to Tauri's patterns (e.g., `too_many_arguments` for commands with `AppHandle + State + params`)
+
+The result: `cargo clippy --workspace -- -D warnings` passes clean, and new code gets meaningful feedback from ~40 enforced pedantic lints.
+
+We also tuned `clippy.toml` thresholds for this codebase:
+
+```toml
+cognitive-complexity-threshold = 30   # agentic loops are inherently complex
+too-many-lines-threshold = 120
+too-many-arguments-threshold = 9      # Tauri commands have many params
+```
+
+### 3. Rustfmt Configuration
+
+We created a `rustfmt.toml` that codifies the actual code style (4-space indentation, 100 char width) and ran `cargo fmt --all` to normalize the entire codebase. This means AI-generated code that passes `cargo fmt --check` is guaranteed to match the project style.
+
+### 4. GitHub Actions CI
+
+Three parallel jobs that enforce everything:
+
+1. **rust-check** — `cargo check` + `cargo fmt --check` + `cargo clippy -- -D warnings`
+2. **rust-test** — `cargo test --workspace --lib` (depends on rust-check)
+3. **ts-check** — `bun install` + TypeScript typecheck (independent)
+
+The CI runs on `paths: ['solo/**']` so it only triggers on Solo changes. The desktop crate is excluded from clippy/test because `tauri::generate_context!()` requires the frontend `dist` directory.
+
+---
+
+## The Fixes: What Clippy Caught
+
+Enabling pedantic across the workspace surfaced ~100 warnings in existing code. Here's what the meaningful ones taught us:
+
+- **`redundant_closure`** (12 instances) — `.map_err(|e| FsError::Io(e))` became `.map_err(FsError::Io)`. Simpler, more idiomatic.
+
+- **`format!` appended to String** (9 instances) — `result.push_str(&format!("..."))` wastes an allocation. Replaced with `write!(result, "...")` using `std::fmt::Write`.
+
+- **`lazy_static!` superseded** — Replaced with `std::sync::LazyLock`, removing the `lazy_static` dependency entirely.
+
+- **`implicit_saturating_sub`** — Manual `if now >= expires_at { 0 } else { expires_at - now }` replaced with `expires_at.saturating_sub(now)`.
+
+- **Dead code fields** — API response structs with deserialized fields that were never read. Annotated with `#[allow(dead_code)]` since the fields are intentionally populated by serde.
+
+- **Unused async** — Three functions marked `async` with no `.await` inside. Removed the `async` keyword.
+
+- **Unchecked Duration subtraction** — `now - Duration::from_secs(60)` can panic if `now` is less than 60 seconds old. Changed to `now.checked_sub(Duration::from_secs(60)).unwrap_or(now)`.
+
+---
+
+## Results
+
+After this work:
+
+| Check | Status |
+|-------|--------|
+| `cargo fmt --all -- --check` | Pass |
+| `cargo clippy --workspace --exclude solo-desktop -- -D warnings` | Pass |
+| `cargo test --workspace --lib --exclude solo-desktop` | 38/38 pass |
+
+**For AI tools specifically:**
+- Claude Code can now look at `CLAUDE.md` and know exactly how to structure errors, handle async, manage locks, and tag serde enums
+- Every Rust change gets validated by pedantic clippy before the developer sees it
+- CI ensures no regression — AI tools can verify their work automatically
+
+---
+
+## The Learning Curve Trade-Off
+
+Tigran's article makes an important observation: while Rust has a steep learning curve, AI tools excel at handling ownership and borrowing. The developer concentrates on architecture; the AI figures out which combination of `&`, `Arc`, `RwLock`, and lifetime annotations makes the code compile.
+
+Our experience confirms this. The most productive pattern is:
+
+1. **Human decides** the function signature and error types
+2. **AI generates** the implementation
+3. **Compiler verifies** memory safety and type correctness
+4. **Clippy refines** style and catches subtle issues
+5. **Human reviews** logic and architecture
+
+The infrastructure we built — `CLAUDE.md`, clippy pedantic, rustfmt, CI — makes step 2 dramatically more likely to produce correct code on the first attempt, and makes steps 3-4 automatic.
+
+---
+
+## Files Changed
+
+| File | Description |
+|------|-------------|
+| `solo/CLAUDE.md` | Added 7 new Rust-specific sections |
+| `solo/clippy.toml` | Tuned thresholds for this codebase |
+| `solo/rustfmt.toml` | Codified actual code style |
+| `solo/crates/*/src/lib.rs` (7 files) | Added pedantic lint attributes |
+| `.github/workflows/ci.yml` | Three-job CI pipeline |
+| `.claude/skills/solo-rust-ai-skill/` | Reusable skill for AI Rust coding |
+| ~40 Rust source files | Fixed clippy warnings |
+
+---
+
+## References
+
+- [Coding Rust with Claude Code and Codex](https://tigran.tech/coding-rust-with-claude-code-and-codex/) — the article that inspired this work
+- [Clippy Lint Reference](https://rust-lang.github.io/rust-clippy/master/index.html)
+- [Tauri 2 Commands](https://v2.tauri.app/develop/calling-rust/)

--- a/docs/Claude/sandboxing.md
+++ b/docs/Claude/sandboxing.md
@@ -1,0 +1,261 @@
+> ## Documentation Index
+> Fetch the complete documentation index at: https://code.claude.com/docs/llms.txt
+> Use this file to discover all available pages before exploring further.
+
+# Sandboxing
+
+> Learn how Claude Code's sandboxed bash tool provides filesystem and network isolation for safer, more autonomous agent execution.
+
+## Overview
+
+Claude Code features native sandboxing to provide a more secure environment for agent execution while reducing the need for constant permission prompts. Instead of asking permission for each bash command, sandboxing creates defined boundaries upfront where Claude Code can work more freely with reduced risk.
+
+The sandboxed bash tool uses OS-level primitives to enforce both filesystem and network isolation.
+
+## Why sandboxing matters
+
+Traditional permission-based security requires constant user approval for bash commands. While this provides control, it can lead to:
+
+* **Approval fatigue**: Repeatedly clicking "approve" can cause users to pay less attention to what they're approving
+* **Reduced productivity**: Constant interruptions slow down development workflows
+* **Limited autonomy**: Claude Code cannot work as efficiently when waiting for approvals
+
+Sandboxing addresses these challenges by:
+
+1. **Defining clear boundaries**: Specify exactly which directories and network hosts Claude Code can access
+2. **Reducing permission prompts**: Safe commands within the sandbox don't require approval
+3. **Maintaining security**: Attempts to access resources outside the sandbox trigger immediate notifications
+4. **Enabling autonomy**: Claude Code can run more independently within defined limits
+
+<Warning>
+  Effective sandboxing requires **both** filesystem and network isolation. Without network isolation, a compromised agent could exfiltrate sensitive files like SSH keys. Without filesystem isolation, a compromised agent could backdoor system resources to gain network access. When configuring sandboxing it is important to ensure that your configured settings do not create bypasses in these systems.
+</Warning>
+
+## How it works
+
+### Filesystem isolation
+
+The sandboxed bash tool restricts file system access to specific directories:
+
+* **Default writes behavior**: Read and write access to the current working directory and its subdirectories
+* **Default read behavior**: Read access to the entire computer, except certain denied directories
+* **Blocked access**: Cannot modify files outside the current working directory without explicit permission
+* **Configurable**: Define custom allowed and denied paths through settings
+
+### Network isolation
+
+Network access is controlled through a proxy server running outside the sandbox:
+
+* **Domain restrictions**: Only approved domains can be accessed
+* **User confirmation**: New domain requests trigger permission prompts
+* **Custom proxy support**: Advanced users can implement custom rules on outgoing traffic
+* **Comprehensive coverage**: Restrictions apply to all scripts, programs, and subprocesses spawned by commands
+
+### OS-level enforcement
+
+The sandboxed bash tool leverages operating system security primitives:
+
+* **macOS**: Uses Seatbelt for sandbox enforcement
+* **Linux**: Uses [bubblewrap](https://github.com/containers/bubblewrap) for isolation
+* **WSL2**: Uses bubblewrap, same as Linux
+
+WSL1 is not supported because bubblewrap requires kernel features only available in WSL2.
+
+These OS-level restrictions ensure that all child processes spawned by Claude Code's commands inherit the same security boundaries.
+
+## Getting started
+
+### Prerequisites
+
+On **macOS**, sandboxing works out of the box using the built-in Seatbelt framework.
+
+On **Linux and WSL2**, install the required packages first:
+
+<Tabs>
+  <Tab title="Ubuntu/Debian">
+    ```bash  theme={null}
+    sudo apt-get install bubblewrap socat
+    ```
+  </Tab>
+
+  <Tab title="Fedora">
+    ```bash  theme={null}
+    sudo dnf install bubblewrap socat
+    ```
+  </Tab>
+</Tabs>
+
+### Enable sandboxing
+
+You can enable sandboxing by running the `/sandbox` command:
+
+```
+> /sandbox
+```
+
+This opens a menu where you can choose between sandbox modes. If required dependencies are missing (such as `bubblewrap` or `socat` on Linux), the menu displays installation instructions for your platform.
+
+### Sandbox modes
+
+Claude Code offers two sandbox modes:
+
+**Auto-allow mode**: Bash commands will attempt to run inside the sandbox and are automatically allowed without requiring permission. Commands that cannot be sandboxed (such as those needing network access to non-allowed hosts) fall back to the regular permission flow. Explicit ask/deny rules you've configured are always respected.
+
+**Regular permissions mode**: All bash commands go through the standard permission flow, even when sandboxed. This provides more control but requires more approvals.
+
+In both modes, the sandbox enforces the same filesystem and network restrictions. The difference is only in whether sandboxed commands are auto-approved or require explicit permission.
+
+<Info>
+  Auto-allow mode works independently of your permission mode setting. Even if you're not in "accept edits" mode, sandboxed bash commands will run automatically when auto-allow is enabled. This means bash commands that modify files within the sandbox boundaries will execute without prompting, even when file edit tools would normally require approval.
+</Info>
+
+### Configure sandboxing
+
+Customize sandbox behavior through your `settings.json` file. See [Settings](/en/settings#sandbox-settings) for complete configuration reference.
+
+<Tip>
+  Not all commands are compatible with sandboxing out of the box. Some notes that may help you make the most out of the sandbox:
+
+  * Many CLI tools require accessing certain hosts. As you use these tools, they will request permission to access certain hosts. Granting permission will allow them to access these hosts now and in the future, enabling them to safely execute inside the sandbox.
+  * `watchman` is incompatible with running in the sandbox. If you're running `jest`, consider using `jest --no-watchman`
+  * `docker` is incompatible with running in the sandbox. Consider specifying `docker` in `excludedCommands` to force it to run outside of the sandbox.
+</Tip>
+
+<Note>
+  Claude Code includes an intentional escape hatch mechanism that allows commands to run outside the sandbox when necessary. When a command fails due to sandbox restrictions (such as network connectivity issues or incompatible tools), Claude is prompted to analyze the failure and may retry the command with the `dangerouslyDisableSandbox` parameter. Commands that use this parameter go through the normal Claude Code permissions flow requiring user permission to execute. This allows Claude Code to handle edge cases where certain tools or network operations cannot function within sandbox constraints.
+
+  You can disable this escape hatch by setting `"allowUnsandboxedCommands": false` in your [sandbox settings](/en/settings#sandbox-settings). When disabled, the `dangerouslyDisableSandbox` parameter is completely ignored and all commands must run sandboxed or be explicitly listed in `excludedCommands`.
+</Note>
+
+## Security benefits
+
+### Protection against prompt injection
+
+Even if an attacker successfully manipulates Claude Code's behavior through prompt injection, the sandbox ensures your system remains secure:
+
+**Filesystem protection:**
+
+* Cannot modify critical config files such as `~/.bashrc`
+* Cannot modify system-level files in `/bin/`
+* Cannot read files that are denied in your [Claude permission settings](/en/permissions#manage-permissions)
+
+**Network protection:**
+
+* Cannot exfiltrate data to attacker-controlled servers
+* Cannot download malicious scripts from unauthorized domains
+* Cannot make unexpected API calls to unapproved services
+* Cannot contact any domains not explicitly allowed
+
+**Monitoring and control:**
+
+* All access attempts outside the sandbox are blocked at the OS level
+* You receive immediate notifications when boundaries are tested
+* You can choose to deny, allow once, or permanently update your configuration
+
+### Reduced attack surface
+
+Sandboxing limits the potential damage from:
+
+* **Malicious dependencies**: NPM packages or other dependencies with harmful code
+* **Compromised scripts**: Build scripts or tools with security vulnerabilities
+* **Social engineering**: Attacks that trick users into running dangerous commands
+* **Prompt injection**: Attacks that trick Claude into running dangerous commands
+
+### Transparent operation
+
+When Claude Code attempts to access network resources outside the sandbox:
+
+1. The operation is blocked at the OS level
+2. You receive an immediate notification
+3. You can choose to:
+   * Deny the request
+   * Allow it once
+   * Update your sandbox configuration to permanently allow it
+
+## Security Limitations
+
+* Network Sandboxing Limitations: The network filtering system operates by restricting the domains that processes are allowed to connect to. It does not otherwise inspect the traffic passing through the proxy and users are responsible for ensuring they only allow trusted domains in their policy.
+
+<Warning>
+  Users should be aware of potential risks that come from allowing broad domains like `github.com` that may allow for data exfiltration. Also, in some cases it may be possible to bypass the network filtering through [domain fronting](https://en.wikipedia.org/wiki/Domain_fronting).
+</Warning>
+
+* Privilege Escalation via Unix Sockets: The `allowUnixSockets` configuration can inadvertently grant access to powerful system services that could lead to sandbox bypasses. For example, if it is used to allow access to `/var/run/docker.sock` this would effectively grant access to the host system through exploiting the docker socket. Users are encouraged to carefully consider any unix sockets that they allow through the sandbox.
+* Filesystem Permission Escalation: Overly broad filesystem write permissions can enable privilege escalation attacks. Allowing writes to directories containing executables in `$PATH`, system configuration directories, or user shell configuration files (`.bashrc`, `.zshrc`) can lead to code execution in different security contexts when other users or system processes access these files.
+* Linux Sandbox Strength: The Linux implementation provides strong filesystem and network isolation but includes an `enableWeakerNestedSandbox` mode that enables it to work inside of Docker environments without privileged namespaces. This option considerably weakens security and should only be used in cases where additional isolation is otherwise enforced.
+
+## How sandboxing relates to permissions
+
+Sandboxing and [permissions](/en/permissions) are complementary security layers that work together:
+
+* **Permissions** control which tools Claude Code can use and are evaluated before any tool runs. They apply to all tools: Bash, Read, Edit, WebFetch, MCP, and others.
+* **Sandboxing** provides OS-level enforcement that restricts what Bash commands can access at the filesystem and network level. It applies only to Bash commands and their child processes.
+
+Filesystem and network restrictions are configured through permission rules, not sandbox settings:
+
+* Use `Read` and `Edit` deny rules to block access to specific files or directories
+* Use `WebFetch` allow/deny rules to control domain access
+* Use sandbox `allowedDomains` to control which domains Bash commands can reach
+
+This [repository](https://github.com/anthropics/claude-code/tree/main/examples/settings) includes starter settings configurations for common deployment scenarios, including sandbox-specific examples. Use these as starting points and adjust them to fit your needs.
+
+## Advanced usage
+
+### Custom proxy configuration
+
+For organizations requiring advanced network security, you can implement a custom proxy to:
+
+* Decrypt and inspect HTTPS traffic
+* Apply custom filtering rules
+* Log all network requests
+* Integrate with existing security infrastructure
+
+```json  theme={null}
+{
+  "sandbox": {
+    "network": {
+      "httpProxyPort": 8080,
+      "socksProxyPort": 8081
+    }
+  }
+}
+```
+
+### Integration with existing security tools
+
+The sandboxed bash tool works alongside:
+
+* **Permission rules**: Combine with [permission settings](/en/permissions) for defense-in-depth
+* **Development containers**: Use with [devcontainers](/en/devcontainer) for additional isolation
+* **Enterprise policies**: Enforce sandbox configurations through [managed settings](/en/settings#settings-precedence)
+
+## Best practices
+
+1. **Start restrictive**: Begin with minimal permissions and expand as needed
+2. **Monitor logs**: Review sandbox violation attempts to understand Claude Code's needs
+3. **Use environment-specific configs**: Different sandbox rules for development vs. production contexts
+4. **Combine with permissions**: Use sandboxing alongside IAM policies for comprehensive security
+5. **Test configurations**: Verify your sandbox settings don't block legitimate workflows
+
+## Open source
+
+The sandbox runtime is available as an open source npm package for use in your own agent projects. This enables the broader AI agent community to build safer, more secure autonomous systems. This can also be used to sandbox other programs you may wish to run. For example, to sandbox an MCP server you could run:
+
+```bash  theme={null}
+npx @anthropic-ai/sandbox-runtime <command-to-sandbox>
+```
+
+For implementation details and source code, visit the [GitHub repository](https://github.com/anthropic-experimental/sandbox-runtime).
+
+## Limitations
+
+* **Performance overhead**: Minimal, but some filesystem operations may be slightly slower
+* **Compatibility**: Some tools that require specific system access patterns may need configuration adjustments, or may even need to be run outside of the sandbox
+* **Platform support**: Supports macOS, Linux, and WSL2. WSL1 is not supported. Native Windows support is planned.
+
+## See also
+
+* [Security](/en/security) - Comprehensive security features and best practices
+* [Permissions](/en/permissions) - Permission configuration and access control
+* [Settings](/en/settings) - Complete configuration reference
+* [CLI reference](/en/cli-reference) - Command-line options

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,6 @@
+edition = "2021"
+max_width = 100
+hard_tabs = false
+tab_spaces = 4
+newline_style = "Auto"
+use_small_heuristics = "Default"


### PR DESCRIPTION
## Summary

- Adds `clippy.toml` (tuned thresholds) and `rustfmt.toml` (consistent 100-char width, 4-space indent) to enforce Rust code quality standards
- Enables `#![warn(clippy::all, clippy::pedantic)]` with curated allow lists across all 8 crates (solo-core, solo-fs, solo-parse, solo-embeddings, solo-protocol, solo-agent, solo-git, solo-desktop)
- Fixes all clippy warnings: redundant closures, `format_push_string`, `bool_to_int_with_if`, `implicit_clone`, `unused_async`, `derivable_impls`, `needless_pass_by_value`
- Replaces `lazy_static` with `std::sync::LazyLock` (removes dependency)
- Normalizes formatting with `cargo fmt --all`
- Adds Rust AI coding infrastructure, permissions, and sandboxing documentation

Supersedes #34 — rebased onto current master to avoid 19 merge conflicts from the solo-agent refactor.

## Verification

| Check | Result |
|-------|--------|
| `cargo fmt --all -- --check` | Pass |
| `cargo clippy --workspace --exclude solo-desktop -- -D warnings` | Pass (0 errors) |
| `cargo test --workspace --lib --exclude solo-desktop` | 126/126 pass |

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --exclude solo-desktop -- -D warnings` passes clean
- [x] All 126 library tests pass across 7 crates
- [ ] `bun run dev` builds and launches successfully