### PR TITLE
Tab bar capsule treatment and interactive file breadcrumbs

### DIFF
--- a/apps/desktop/src/components/panels/FileViewerPanel.tsx
+++ b/apps/desktop/src/components/panels/FileViewerPanel.tsx
@@ -7,13 +7,16 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import Editor, { OnMount, BeforeMount } from '@monaco-editor/react';
 import type * as Monaco from 'monaco-editor';
-import { WarningCircle } from '@phosphor-icons/react';
+import { WarningCircle, CaretRight } from '@phosphor-icons/react';
+import { FileIcon } from '@react-symbols/icons/utils';
 import { CodeSkeleton } from '@/components/ui/skeletons';
 import * as fs from '@/lib/tauri/fs';
 import { registerSoloTheme, SOLO_THEME_NAME, SOLO_LIGHT_THEME_NAME, registerSoloLightTheme } from '@/components/editor/theme';
 import { MarkdownEditor } from '@/components/editor/MarkdownEditor';
 import { MarkdownToggle } from '@/components/editor/MarkdownToggle';
 import { useSettingsStore } from '@/stores/settingsStore';
+import { useFileExplorerStore } from '@/stores/fileExplorerStore';
+import { useUIStore } from '@/stores/uiStore';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import type { PanelProps } from '@/lib/panels/types';
 import type { MarkdownMode } from '@/stores/editorStore';
@@ -30,6 +33,27 @@ function isMarkdownFile(path: string | undefined): boolean {
   if (!path) return false;
   const ext = path.split('.').pop()?.toLowerCase() ?? '';
   return ext === 'md' || ext === 'markdown';
+}
+
+interface BreadcrumbSegment {
+  label: string;
+  fullPath: string;
+  isLast: boolean;
+}
+
+function buildBreadcrumbSegments(filePath: string, rootPath: string | null): BreadcrumbSegment[] {
+  let displayPath = filePath;
+  if (rootPath && filePath.startsWith(rootPath)) {
+    displayPath = filePath.slice(rootPath.length).replace(/^\//, '');
+  }
+  const parts = displayPath.split('/').filter(Boolean);
+  const segments: BreadcrumbSegment[] = [];
+  let currentPath = rootPath ?? '';
+  for (let i = 0; i < parts.length; i++) {
+    currentPath = currentPath ? `${currentPath}/${parts[i]}` : parts[i];
+    segments.push({ label: parts[i], fullPath: currentPath, isLast: i === parts.length - 1 });
+  }
+  return segments;
 }
 
 /**
@@ -148,6 +172,27 @@ export function FileViewerPanel({
 
   // Check if current file is markdown
   const isMarkdown = useMemo(() => isMarkdownFile(filePath), [filePath]);
+
+  // Breadcrumb navigation
+  const rootPath = useFileExplorerStore((s) => s.rootPath);
+  const expandDirectory = useFileExplorerStore((s) => s.expandDirectory);
+  const selectFile = useFileExplorerStore((s) => s.selectFile);
+  const setActiveTab = useUIStore((s) => s.setActiveTab);
+
+  const breadcrumbSegments = useMemo(
+    () => (filePath ? buildBreadcrumbSegments(filePath, rootPath) : []),
+    [filePath, rootPath]
+  );
+
+  const handleBreadcrumbClick = useCallback(
+    async (segment: BreadcrumbSegment) => {
+      if (segment.isLast) return;
+      setActiveTab('explorer');
+      await expandDirectory(segment.fullPath);
+      selectFile(segment.fullPath);
+    },
+    [setActiveTab, expandDirectory, selectFile]
+  );
 
   // Update title based on file name
   useEffect(() => {
@@ -403,9 +448,36 @@ export function FileViewerPanel({
 
   return (
     <div className="flex flex-col h-full bg-background">
-      {/* Breadcrumb with markdown toggle */}
-      <div className="flex items-center justify-between h-6 px-3 bg-muted/30 border-b border-border/30 shrink-0">
-        <span className="text-[11px] text-muted-foreground truncate flex-1">{filePath}</span>
+      {/* Interactive breadcrumb with markdown toggle */}
+      <div className="flex items-center justify-between h-6 px-3 bg-background/40 backdrop-blur-md border-b border-white/[0.04] shrink-0">
+        <div className="flex items-center gap-1 overflow-x-auto scrollbar-none flex-1 min-w-0">
+          {breadcrumbSegments.length > 0 && (
+            <FileIcon
+              fileName={breadcrumbSegments[breadcrumbSegments.length - 1].label}
+              autoAssign
+              className="w-3.5 h-3.5 shrink-0"
+            />
+          )}
+          {breadcrumbSegments.map((segment, i) => (
+            <div key={segment.fullPath} className="flex items-center gap-1 shrink-0">
+              {i > 0 && (
+                <CaretRight className="w-2.5 h-2.5 text-muted-foreground/40 shrink-0" weight="bold" />
+              )}
+              {segment.isLast ? (
+                <span className="text-[11px] text-foreground/80 font-medium whitespace-nowrap">
+                  {segment.label}
+                </span>
+              ) : (
+                <button
+                  className="text-[11px] text-muted-foreground/60 hover:text-foreground transition-colors duration-100 whitespace-nowrap"
+                  onClick={() => handleBreadcrumbClick(segment)}
+                >
+                  {segment.label}
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
         {isMarkdown && (
           <MarkdownToggle
             mode={markdownMode}
@@ -428,12 +500,15 @@ export function FileViewerPanel({
       </div>
 
       {/* Status bar */}
-      <div className="flex items-center justify-between h-6 px-3 bg-primary text-primary-foreground text-[12px] shrink-0">
-        <div className="flex items-center gap-4">
-          <span>{language}</span>
-          <span>UTF-8</span>
+      <div className="flex items-center justify-between h-6 px-3 bg-background/30 backdrop-blur-md text-muted-foreground text-[11px] border-t border-white/[0.04] shrink-0">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1.5">
+            <span className="w-1.5 h-1.5 rounded-full bg-primary/60 shrink-0" />
+            <span>{language}</span>
+          </div>
+          <span className="text-muted-foreground/50">UTF-8</span>
         </div>
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-3 text-muted-foreground/60">
           <span>Ln {cursorPosition.line}, Col {cursorPosition.col}</span>
           <span>{lineCount} lines</span>
         </div>

--- a/apps/desktop/src/components/panels/Tab.tsx
+++ b/apps/desktop/src/components/panels/Tab.tsx
@@ -5,6 +5,7 @@
 
 import { useCallback, type MouseEvent } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
+import { motion } from 'motion/react';
 import { X, PushPin } from '@phosphor-icons/react';
 import { cn } from '@/lib/utils';
 import type { PanelInstance, TileId, PanelInstanceId, TabDragItem } from '@/lib/panels/types';
@@ -134,13 +135,13 @@ export function Tab({
       tabIndex={isActive ? 0 : -1}
       className={cn(
         'group relative flex items-center gap-1.5 h-[35px] px-3',
-        'border-r border-border/20',
+        'border-r border-white/[0.03]',
         'transition-[background-color,color] duration-150 ease-out',
         'cursor-pointer select-none',
         'shrink-0 min-w-[80px] max-w-[200px]',
         isActive
-          ? 'bg-card/60 text-foreground'
-          : 'bg-transparent text-muted-foreground hover:text-foreground hover:bg-muted/40',
+          ? 'bg-primary/10 backdrop-blur-md text-foreground shadow-[0_1px_4px_-1px_rgba(0,0,0,0.12)] rounded-t-lg'
+          : 'bg-transparent text-muted-foreground hover:text-foreground hover:bg-white/[0.04]',
         isDragging && 'opacity-50',
         isOver && !isDragging && 'bg-primary/10'
       )}
@@ -185,9 +186,16 @@ export function Tab({
         </button>
       )}
 
-      {/* Active tab indicator line */}
+      {/* Active tab indicator - animated sliding accent */}
       {isActive && (
-        <div className="absolute bottom-0 left-0 right-0 h-px bg-primary/60" />
+        <motion.div
+          layoutId={`tab-indicator-${tileId}`}
+          className="absolute bottom-0 left-1 right-1 h-[2.5px] rounded-full bg-primary/70"
+          style={{
+            boxShadow: '0 0 8px 0 oklch(from var(--primary) l c h / 30%)',
+          }}
+          transition={{ type: 'spring', stiffness: 500, damping: 35 }}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
Active tabs now have a green-tinted pill background with rounded top corners and a 2.5px animated accent that slides between tabs via shared layout animation. Breadcrumb bar shows file icon with clickable directory segments that navigate the file explorer sidebar.