### PR TITLE
Fix agent sessions lost when navigating to settings and back

### DIFF
--- a/apps/desktop/src/lib/panels/usePersistence.ts
+++ b/apps/desktop/src/lib/panels/usePersistence.ts
@@ -13,18 +13,22 @@ import {
   createDebouncedSave,
 } from './persistence';
 
+// Module-level flag: survives component remounts (e.g. settings toggle),
+// only resets on full page reload (app restart) when we actually need to
+// restore from localStorage.
+let persistenceInitialized = false;
+
 /**
  * Hook to handle layout persistence
  * Should be called once at the root of the panel system
  */
 export function usePersistence() {
-  const isInitialized = useRef(false);
   const debouncedSaveRef = useRef(createDebouncedSave());
 
-  // Load persisted layout on mount
+  // Load persisted layout on mount (only on first app load, not on view transitions)
   useEffect(() => {
-    if (isInitialized.current) return;
-    isInitialized.current = true;
+    if (persistenceInitialized) return;
+    persistenceInitialized = true;
 
     const persisted = loadLayout();
     if (!persisted) return;


### PR DESCRIPTION
usePersistence used useRef for its initialization guard, which resets on component remount. When toggling settings, MosaicLayout remounts and the effect re-runs, overwriting in-memory state with localStorage data that excludes ephemeral panels (agent, terminal, diff).

Move the guard to a module-level variable so it survives remounts and only resets on full page reload.