### PR TITLE
Normalize font sizes to Tailwind tokens and improve light mode contrast

### DIFF
--- a/apps/desktop/src/components/agent/SessionList.tsx
+++ b/apps/desktop/src/components/agent/SessionList.tsx
@@ -226,8 +226,8 @@ const SessionItem: FC<{
             />
           ) : (
             <>
-              <span className="text-[12.5px] truncate block">{title}</span>
-              <span className="text-[11px] text-muted-foreground/60 truncate block">
+              <span className="text-sm truncate block">{title}</span>
+              <span className="text-xs text-muted-foreground/60 truncate block">
                 {formatSessionDate(session.createdAt)}
               </span>
             </>

--- a/apps/desktop/src/components/editor/Breadcrumbs.tsx
+++ b/apps/desktop/src/components/editor/Breadcrumbs.tsx
@@ -50,12 +50,12 @@ export function Breadcrumbs({
     <div
       className={`flex items-center justify-between h-7 px-3 bg-background/80 backdrop-blur-sm border-b border-border/20 ${className}`}
     >
-      <div className="flex items-center gap-1 text-[11px] whitespace-nowrap overflow-x-auto">
+      <div className="flex items-center gap-1 text-xs whitespace-nowrap overflow-x-auto">
         {/* Directory path */}
         {dirPath && (
           <>
-            <span className="text-muted-foreground/70 truncate max-w-[200px]">{dirPath}</span>
-            <CaretRight className="w-3 h-3 text-muted-foreground/50 shrink-0" />
+            <span className="text-muted-foreground truncate max-w-[200px]">{dirPath}</span>
+            <CaretRight className="w-3 h-3 text-muted-foreground/60 shrink-0" />
           </>
         )}
 
@@ -71,13 +71,13 @@ export function Breadcrumbs({
         {/* Symbol path */}
         {symbolPath.map((symbol, i) => (
           <div key={i} className="flex items-center gap-1">
-            <CaretRight className="w-3 h-3 text-muted-foreground/50 shrink-0" />
+            <CaretRight className="w-3 h-3 text-muted-foreground/60 shrink-0" />
             <button
               onClick={() => onSymbolClick?.(symbol)}
               className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors duration-150"
               title={`Go to ${symbol.name}`}
             >
-              <span className="font-mono text-[10px]">{getSymbolIcon(symbol.kind)}</span>
+              <span className="font-mono text-2xs">{getSymbolIcon(symbol.kind)}</span>
               <span>{symbol.name}</span>
             </button>
           </div>

--- a/apps/desktop/src/components/file-explorer/CreationRow.tsx
+++ b/apps/desktop/src/components/file-explorer/CreationRow.tsx
@@ -70,7 +70,7 @@ export function CreationRow({ type, depth, style, onSubmit, onCancel }: Creation
           onBlur={commit}
           autoFocus
           placeholder={type === 'file' ? 'filename' : 'folder name'}
-          className="flex-1 min-w-0 px-1 py-0 text-xs font-medium bg-muted border border-primary rounded outline-none"
+          className="flex-1 min-w-0 px-1 py-0 text-sm font-medium bg-muted border border-primary rounded outline-none"
           onClick={(e) => e.stopPropagation()}
         />
       </div>

--- a/apps/desktop/src/components/file-explorer/FileTreeNode.tsx
+++ b/apps/desktop/src/components/file-explorer/FileTreeNode.tsx
@@ -266,11 +266,11 @@ export const FileTreeNode = memo(function FileTreeNode({
             onBlur={handleRenameBlur}
             autoFocus
             aria-label={`Rename ${entry.name}`}
-            className="flex-1 min-w-0 px-1 py-0 text-xs font-medium bg-muted border border-primary rounded outline-none"
+            className="flex-1 min-w-0 px-1 py-0 text-sm font-medium bg-muted border border-primary rounded outline-none"
             onClick={(e) => e.stopPropagation()}
           />
         ) : (
-          <span className="truncate text-xs font-medium text-foreground">{entry.name}</span>
+          <span className="truncate text-sm font-medium text-foreground">{entry.name}</span>
         )}
       </div>
 

--- a/apps/desktop/src/components/panels/FileDiffSection.tsx
+++ b/apps/desktop/src/components/panels/FileDiffSection.tsx
@@ -23,7 +23,7 @@ const statusBadgeClass: Record<string, string> = {
 const UnmodifiedGap = memo(({ count }: { count: number }) => {
   if (count <= 0) return null;
   return (
-    <div className="flex items-center justify-center h-6 text-[10px] text-muted-foreground/40 bg-muted/20 select-none">
+    <div className="flex items-center justify-center h-6 text-2xs text-muted-foreground/40 bg-muted/20 select-none">
       {count} unmodified line{count !== 1 ? 's' : ''}
     </div>
   );
@@ -132,10 +132,10 @@ export const FileDiffSection = memo(({ file, defaultOpen = true }: FileDiffSecti
         )}
         <span className="truncate text-foreground">{fileName}</span>
         {dirPath && (
-          <span className="truncate text-muted-foreground/50 text-[10px]">{dirPath}</span>
+          <span className="truncate text-muted-foreground/60 text-2xs">{dirPath}</span>
         )}
         <span className="ml-auto flex items-center gap-2 shrink-0">
-          <span className="flex items-center gap-1 text-[10px]">
+          <span className="flex items-center gap-1 text-2xs">
             {file.additions > 0 && (
               <span className="text-emerald-400">+{file.additions}</span>
             )}
@@ -145,7 +145,7 @@ export const FileDiffSection = memo(({ file, defaultOpen = true }: FileDiffSecti
           </span>
           <span
             className={cn(
-              'px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase',
+              'px-1.5 py-0.5 rounded text-2xs font-semibold uppercase',
               statusBadgeClass[file.status] ?? 'bg-muted/50 text-muted-foreground',
             )}
           >

--- a/apps/desktop/src/components/panels/FileViewerPanel.tsx
+++ b/apps/desktop/src/components/panels/FileViewerPanel.tsx
@@ -464,12 +464,12 @@ export function FileViewerPanel({
                 <CaretRight className="w-2.5 h-2.5 text-muted-foreground/40 shrink-0" weight="bold" />
               )}
               {segment.isLast ? (
-                <span className="text-[11px] text-foreground/80 font-medium whitespace-nowrap">
+                <span className="text-xs text-foreground/80 font-medium whitespace-nowrap">
                   {segment.label}
                 </span>
               ) : (
                 <button
-                  className="text-[11px] text-muted-foreground/60 hover:text-foreground transition-colors duration-100 whitespace-nowrap"
+                  className="text-xs text-muted-foreground/60 hover:text-foreground transition-colors duration-100 whitespace-nowrap"
                   onClick={() => handleBreadcrumbClick(segment)}
                 >
                   {segment.label}
@@ -500,13 +500,13 @@ export function FileViewerPanel({
       </div>
 
       {/* Status bar */}
-      <div className="flex items-center justify-between h-6 px-3 bg-background/30 backdrop-blur-md text-muted-foreground text-[11px] border-t border-white/[0.04] shrink-0">
+      <div className="flex items-center justify-between h-6 px-3 bg-background/30 backdrop-blur-md text-muted-foreground text-xs border-t border-white/[0.04] shrink-0">
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-1.5">
             <span className="w-1.5 h-1.5 rounded-full bg-primary/60 shrink-0" />
             <span>{language}</span>
           </div>
-          <span className="text-muted-foreground/50">UTF-8</span>
+          <span className="text-muted-foreground/60">UTF-8</span>
         </div>
         <div className="flex items-center gap-3 text-muted-foreground/60">
           <span>Ln {cursorPosition.line}, Col {cursorPosition.col}</span>

--- a/apps/desktop/src/components/panels/TabbedContainer.tsx
+++ b/apps/desktop/src/components/panels/TabbedContainer.tsx
@@ -290,9 +290,9 @@ function EmptyTile() {
         <p className="text-muted-foreground/60 text-xs">Open a file from the explorer</p>
         <button
           onClick={handleNewChat}
-          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-primary-foreground bg-primary rounded-lg hover:brightness-110 active:scale-[0.97] transition-all duration-200"
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-primary-foreground bg-primary rounded-lg hover:brightness-110 active:scale-[0.97] transition-all duration-200"
         >
-          <ChatCircle className="w-3.5 h-3.5" weight="bold" />
+          <ChatCircle className="w-4 h-4" weight="bold" />
           New AI Chat
         </button>
       </div>

--- a/apps/desktop/src/components/panels/WorktreeDiffPanel.tsx
+++ b/apps/desktop/src/components/panels/WorktreeDiffPanel.tsx
@@ -83,7 +83,7 @@ export const WorktreeDiffPanel = ({
   if (entries.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full gap-2 px-6">
-        <File className="w-8 h-8 text-muted-foreground/30" />
+        <File className="w-8 h-8 text-muted-foreground/40" />
         <p className="text-xs text-muted-foreground/60">No changes from base branch</p>
       </div>
     );
@@ -110,16 +110,16 @@ export const WorktreeDiffPanel = ({
               <Icon className={cn('w-3.5 h-3.5 shrink-0', config.color.split(' ')[0])} />
               <span className="text-xs text-foreground truncate">{fileName}</span>
               {dirPath && (
-                <span className="text-[10px] text-muted-foreground/50 truncate">{dirPath}</span>
+                <span className="text-2xs text-muted-foreground/60 truncate">{dirPath}</span>
               )}
-              <span className="ml-auto flex items-center gap-1.5 text-[10px] shrink-0">
+              <span className="ml-auto flex items-center gap-1.5 text-2xs shrink-0">
                 {entry.additions > 0 && (
                   <span className="text-emerald-400">+{entry.additions}</span>
                 )}
                 {entry.deletions > 0 && (
                   <span className="text-red-400">-{entry.deletions}</span>
                 )}
-                <span className={cn('px-1 py-0.5 rounded text-[9px] font-semibold', config.color)}>
+                <span className={cn('px-1 py-0.5 rounded text-2xs font-semibold', config.color)}>
                   {config.label}
                 </span>
               </span>

--- a/apps/desktop/src/components/sidebar/ContextHeader.tsx
+++ b/apps/desktop/src/components/sidebar/ContextHeader.tsx
@@ -215,7 +215,7 @@ const IconButton: FC<IconButtonProps> = ({ onClick, title, icon: Icon, disabled,
   >
     <Icon className={cn('w-3.5 h-3.5', loading && 'animate-spin')} weight="bold" />
     {badge != null && badge > 0 && (
-      <span className="absolute -top-1 -right-1 min-w-[14px] h-[14px] px-0.5 flex items-center justify-center rounded-full bg-primary text-primary-foreground text-[9px] font-semibold leading-none">
+      <span className="absolute -top-1 -right-1 min-w-[14px] h-[14px] px-0.5 flex items-center justify-center rounded-full bg-primary text-primary-foreground text-2xs font-semibold leading-none">
         {badge}
       </span>
     )}

--- a/apps/desktop/src/components/sidebar/CreateWorktreePopover.tsx
+++ b/apps/desktop/src/components/sidebar/CreateWorktreePopover.tsx
@@ -95,7 +95,7 @@ export const CreateWorktreePopover: FC<CreateWorktreePopoverProps> = ({ onClose 
           disabled={isCreating}
           className={cn(
             'w-full h-8 px-2.5 rounded-lg text-xs',
-            'bg-muted/40 border border-border/50 text-foreground placeholder:text-muted-foreground/50',
+            'bg-muted/40 border border-border/50 text-foreground placeholder:text-muted-foreground/60',
             'focus:bg-muted/60 focus:ring-1 focus:ring-ring/30 focus:outline-none',
             'disabled:opacity-50',
             'transition-colors duration-150',
@@ -147,7 +147,7 @@ export const CreateWorktreePopover: FC<CreateWorktreePopoverProps> = ({ onClose 
                     autoFocus
                     className={cn(
                       'w-full h-7 pl-7 pr-2 rounded-md text-xs',
-                      'bg-muted/40 border-none text-foreground placeholder:text-muted-foreground/50',
+                      'bg-muted/40 border-none text-foreground placeholder:text-muted-foreground/60',
                       'focus:outline-none',
                     )}
                   />
@@ -168,7 +168,7 @@ export const CreateWorktreePopover: FC<CreateWorktreePopoverProps> = ({ onClose 
                   )}
                 >
                   <span className="font-medium">HEAD</span>
-                  <span className="text-muted-foreground/50 text-[10px] ml-auto">current</span>
+                  <span className="text-muted-foreground/60 text-2xs ml-auto">current</span>
                 </button>
 
                 {filteredBranches.map((branch) => (
@@ -187,13 +187,13 @@ export const CreateWorktreePopover: FC<CreateWorktreePopoverProps> = ({ onClose 
                     <GitBranch className="w-3 h-3 shrink-0" />
                     <span className="truncate">{branch.name}</span>
                     {branch.is_head && (
-                      <span className="text-[10px] text-primary ml-auto shrink-0">HEAD</span>
+                      <span className="text-2xs text-primary ml-auto shrink-0">HEAD</span>
                     )}
                   </button>
                 ))}
 
                 {filteredBranches.length === 0 && branchFilter && (
-                  <div className="px-2.5 py-3 text-xs text-muted-foreground/50 text-center">
+                  <div className="px-2.5 py-3 text-xs text-muted-foreground/60 text-center">
                     No branches match
                   </div>
                 )}

--- a/apps/desktop/src/components/sidebar/InlineWorktreeList.tsx
+++ b/apps/desktop/src/components/sidebar/InlineWorktreeList.tsx
@@ -160,7 +160,7 @@ const WorktreeRow: FC<WorktreeRowProps> = ({
         'text-xs transition-[background-color,color] duration-150',
         isActive
           ? 'bg-primary/10 text-foreground font-medium'
-          : 'text-muted-foreground/70 hover:bg-muted/40 hover:text-foreground',
+          : 'text-muted-foreground hover:bg-muted/40 hover:text-foreground',
       )}
     >
       <Icon
@@ -174,7 +174,7 @@ const WorktreeRow: FC<WorktreeRowProps> = ({
         <Lock className="w-3 h-3 text-muted-foreground/40 shrink-0" />
       )}
       {worktree.is_dirty && (
-        <CircleDashed className="w-3 h-3 text-yellow-500/60 shrink-0" />
+        <CircleDashed className="w-3 h-3 text-warning-foreground/60 shrink-0" />
       )}
       {worktree.agent_session_id && (
         <Robot className="w-3 h-3 text-primary/60 shrink-0" />

--- a/apps/desktop/src/components/sidebar/RepoCard.tsx
+++ b/apps/desktop/src/components/sidebar/RepoCard.tsx
@@ -89,20 +89,20 @@ export const RepoCard: FC<RepoCardProps> = ({ repo, isActive, children }) => {
             weight={isActive ? 'fill' : 'regular'}
           />
 
-          <span className="text-xs font-medium truncate flex-1">
+          <span className="text-sm font-medium truncate flex-1">
             {repo.name}
           </span>
 
           {/* Branch badge pill */}
           {repo.currentBranch && (
-            <span className="text-[10px] text-muted-foreground/60 bg-muted/30 px-1.5 py-0.5 rounded-full truncate max-w-[80px]">
+            <span className="text-2xs text-muted-foreground/60 bg-muted/30 px-1.5 py-0.5 rounded-full truncate max-w-[80px]">
               {repo.currentBranch}
             </span>
           )}
 
           {/* Worktree count badge */}
           {worktreeCount > 0 && (
-            <span className="text-[10px] text-muted-foreground/50 tabular-nums">
+            <span className="text-2xs text-muted-foreground/60 tabular-nums">
               {worktreeCount}
             </span>
           )}
@@ -113,7 +113,7 @@ export const RepoCard: FC<RepoCardProps> = ({ repo, isActive, children }) => {
             className={cn(
               'w-5 h-5 flex items-center justify-center rounded shrink-0',
               'opacity-0 group-hover:opacity-100 transition-opacity duration-150',
-              'text-muted-foreground/50 hover:text-foreground hover:bg-muted/60',
+              'text-muted-foreground/60 hover:text-foreground hover:bg-muted/60',
             )}
             title="Remove repository"
           >
@@ -123,7 +123,7 @@ export const RepoCard: FC<RepoCardProps> = ({ repo, isActive, children }) => {
 
         {/* Row 2: Status indicators (commits ahead, dirty worktrees) */}
         {hasStatus && (
-          <div className="flex items-center gap-1 h-4 pl-[30px] pr-2 pb-1 text-[10px] text-muted-foreground/60">
+          <div className="flex items-center gap-1 h-4 pl-[30px] pr-2 pb-2 text-2xs text-muted-foreground/60">
             {repo.cachedCommitsAhead > 0 && (
               <span className="flex items-center gap-0.5 text-emerald-400/80">
                 <ArrowUp className="w-2.5 h-2.5" />
@@ -131,10 +131,10 @@ export const RepoCard: FC<RepoCardProps> = ({ repo, isActive, children }) => {
               </span>
             )}
             {repo.cachedCommitsAhead > 0 && repo.dirtyWorktreeCount > 0 && (
-              <span className="text-muted-foreground/30">·</span>
+              <span className="text-muted-foreground/40">·</span>
             )}
             {repo.dirtyWorktreeCount > 0 && (
-              <span className="flex items-center gap-0.5 text-yellow-400/80">
+              <span className="flex items-center gap-0.5 text-warning-foreground/80">
                 <CircleDashed className="w-2.5 h-2.5" />
                 {repo.dirtyWorktreeCount} dirty
               </span>
@@ -144,9 +144,9 @@ export const RepoCard: FC<RepoCardProps> = ({ repo, isActive, children }) => {
 
         {/* Loading indicator */}
         {repo.isExpanded && !repo._worktreesLoaded && (
-          <div className="flex items-center gap-2 h-6 pl-[30px] pr-2 text-muted-foreground/50">
+          <div className="flex items-center gap-2 h-6 pl-[30px] pr-2 text-muted-foreground/60">
             <CircleNotch className="w-3 h-3 animate-spin" />
-            <span className="text-[11px]">Loading...</span>
+            <span className="text-xs">Loading...</span>
           </div>
         )}
       </div>

--- a/apps/desktop/src/components/sidebar/RepoItem.tsx
+++ b/apps/desktop/src/components/sidebar/RepoItem.tsx
@@ -75,18 +75,18 @@ export const RepoItem: FC<RepoItemProps> = ({ repo }) => {
         <Folder className="w-3.5 h-3.5 shrink-0" weight={isActive ? 'fill' : 'regular'} />
 
         {/* Repo name */}
-        <span className="text-xs font-medium truncate flex-1">{repo.name}</span>
+        <span className="text-sm font-medium truncate flex-1">{repo.name}</span>
 
         {/* Branch badge */}
         {repo.currentBranch && (
-          <span className="text-[10px] text-muted-foreground/60 truncate max-w-[80px]">
+          <span className="text-2xs text-muted-foreground/60 truncate max-w-[80px]">
             {repo.currentBranch}
           </span>
         )}
 
         {/* Worktree count badge */}
         {worktreeCount > 0 && (
-          <span className="text-[10px] text-muted-foreground/50 tabular-nums">
+          <span className="text-2xs text-muted-foreground/60 tabular-nums">
             {worktreeCount}
           </span>
         )}
@@ -97,7 +97,7 @@ export const RepoItem: FC<RepoItemProps> = ({ repo }) => {
           className={cn(
             'w-5 h-5 flex items-center justify-center rounded shrink-0',
             'opacity-0 group-hover:opacity-100 transition-opacity duration-150',
-            'text-muted-foreground/50 hover:text-foreground hover:bg-muted/60',
+            'text-muted-foreground/60 hover:text-foreground hover:bg-muted/60',
           )}
           title="Remove repository"
         >
@@ -142,9 +142,9 @@ export const RepoItem: FC<RepoItemProps> = ({ repo }) => {
 
               {/* Loading state */}
               {!repo._worktreesLoaded && (
-                <div className="flex items-center gap-2 h-7 px-2 text-muted-foreground/50">
+                <div className="flex items-center gap-2 h-7 px-2 text-muted-foreground/60">
                   <CircleNotch className="w-3 h-3 animate-spin" />
-                  <span className="text-[11px]">Loading...</span>
+                  <span className="text-xs">Loading...</span>
                 </div>
               )}
             </div>
@@ -184,7 +184,7 @@ const WorktreeRow: FC<WorktreeRowProps> = ({
         'text-xs transition-[background-color,color] duration-150',
         isActive
           ? 'bg-primary/10 text-foreground font-medium'
-          : 'text-muted-foreground/70 hover:bg-muted/40 hover:text-foreground',
+          : 'text-muted-foreground hover:bg-muted/40 hover:text-foreground',
       )}
     >
       <Icon

--- a/apps/desktop/src/components/sidebar/SidebarTerminal.tsx
+++ b/apps/desktop/src/components/sidebar/SidebarTerminal.tsx
@@ -119,7 +119,7 @@ export const SidebarTerminal: FC = () => {
               onMouseDown={(e) => { if (e.button === 1) { e.preventDefault(); handleCloseTab(t.id); } }}
               onDoubleClick={() => rename.startRename(t.id, t.title)}
               className={cn(
-                'group relative flex items-center gap-1 px-3 py-2 text-[11px] max-w-40 shrink-0 cursor-pointer',
+                'group relative flex items-center gap-1 px-3 py-2 text-xs max-w-40 shrink-0 cursor-pointer',
                 'transition-colors duration-150 ease-[cubic-bezier(0.4,0,0.2,1)]',
                 !t.isAlive && 'opacity-60',
                 t.id === activeTerminalId
@@ -132,7 +132,7 @@ export const SidebarTerminal: FC = () => {
                 <input
                   {...rename.getInputProps()}
                   type="text"
-                  className="w-full min-w-[60px] bg-muted/50 outline-none ring-1 ring-primary/40 rounded-[4px] text-[11px] text-foreground px-1.5 py-0.5 -my-0.5 selection:bg-primary/20"
+                  className="w-full min-w-[60px] bg-muted/50 outline-none ring-1 ring-primary/40 rounded-[4px] text-xs text-foreground px-1.5 py-0.5 -my-0.5 selection:bg-primary/20"
                 />
               ) : (
                 <span className="truncate">{t.title}</span>

--- a/apps/desktop/src/components/sidebar/WorktreePanel.tsx
+++ b/apps/desktop/src/components/sidebar/WorktreePanel.tsx
@@ -388,12 +388,12 @@ const WorktreeCard: FC<WorktreeCardProps> = ({
         <div className="mt-1">
           <button
             onClick={(e) => { e.stopPropagation(); setShowSetup(!showSetup); }}
-            className="text-[10px] text-muted-foreground/70 hover:text-muted-foreground"
+            className="text-2xs text-muted-foreground hover:text-muted-foreground"
           >
             {showSetup ? 'Hide setup output' : `Setup (${setupLines.length} lines)`}
           </button>
           {showSetup && (
-            <div className="mt-1 max-h-24 overflow-y-auto bg-black/20 rounded p-1.5 font-mono text-[10px] text-muted-foreground leading-tight">
+            <div className="mt-1 max-h-24 overflow-y-auto bg-black/20 rounded p-1.5 font-mono text-2xs text-muted-foreground leading-tight">
               {setupLines.map((line, i) => (
                 <div key={i} className="whitespace-pre-wrap break-all">{line}</div>
               ))}

--- a/apps/desktop/src/components/sidebar/WorktreeSwitcher.tsx
+++ b/apps/desktop/src/components/sidebar/WorktreeSwitcher.tsx
@@ -119,7 +119,7 @@ export const WorktreeSwitcher: FC<WorktreeSwitcherProps> = ({ onClose }) => {
     >
       {/* Branches section */}
       <div className="flex items-center justify-between px-2.5 py-1.5">
-        <span className="text-[10px] font-medium text-muted-foreground/50 uppercase tracking-wider">
+        <span className="text-2xs font-medium text-muted-foreground/60 uppercase tracking-wider">
           Branches
         </span>
         <button
@@ -153,7 +153,7 @@ export const WorktreeSwitcher: FC<WorktreeSwitcherProps> = ({ onClose }) => {
               disabled={isCreatingBranch}
               className={cn(
                 'flex-1 h-7 px-2 rounded-md text-xs',
-                'bg-muted/40 border-none text-foreground placeholder:text-muted-foreground/50',
+                'bg-muted/40 border-none text-foreground placeholder:text-muted-foreground/60',
                 'focus:bg-muted/60 focus:ring-1 focus:ring-ring/30 focus:outline-none',
                 'disabled:opacity-50',
                 'transition-colors duration-150',
@@ -164,7 +164,7 @@ export const WorktreeSwitcher: FC<WorktreeSwitcherProps> = ({ onClose }) => {
             )}
           </div>
           {branchCreateError && (
-            <p className="mt-1 px-1 text-[10px] text-destructive leading-tight">
+            <p className="mt-1 px-1 text-2xs text-destructive leading-tight">
               {branchCreateError}
             </p>
           )}
@@ -197,7 +197,7 @@ export const WorktreeSwitcher: FC<WorktreeSwitcherProps> = ({ onClose }) => {
 
               {/* Ahead/behind counts */}
               {(branch.ahead > 0 || branch.behind > 0) && (
-                <span className="flex items-center gap-1 text-[10px] text-muted-foreground/60 shrink-0">
+                <span className="flex items-center gap-1 text-2xs text-muted-foreground/60 shrink-0">
                   {branch.ahead > 0 && (
                     <span className="flex items-center gap-0.5">
                       <ArrowUp className="w-2.5 h-2.5" />

--- a/apps/desktop/src/components/source-control/FileChangeItem.tsx
+++ b/apps/desktop/src/components/source-control/FileChangeItem.tsx
@@ -83,7 +83,7 @@ export const FileChangeItem: FC<FileChangeItemProps> = ({ file, onDiscard, onVie
       {/* Status badge */}
       <span
         className={cn(
-          'shrink-0 w-4 h-4 flex items-center justify-center rounded text-[10px] font-bold',
+          'shrink-0 w-4 h-4 flex items-center justify-center rounded text-2xs font-bold',
           STATUS_COLORS[file.status],
           STATUS_BG[file.status],
         )}
@@ -92,18 +92,18 @@ export const FileChangeItem: FC<FileChangeItemProps> = ({ file, onDiscard, onVie
       </span>
 
       {/* File name */}
-      <span className="text-xs text-foreground truncate flex-1">{fileName}</span>
+      <span className="text-sm text-foreground truncate flex-1">{fileName}</span>
 
       {/* Directory path */}
       {dirPath && (
-        <span className="text-[10px] text-muted-foreground/50 truncate max-w-[80px] shrink-0">
+        <span className="text-2xs text-muted-foreground/60 truncate max-w-[80px] shrink-0">
           {dirPath}
         </span>
       )}
 
       {/* Insertions / Deletions */}
       {(file.insertions > 0 || file.deletions > 0) && !isHovered && (
-        <span className="flex items-center gap-0.5 text-[10px] shrink-0">
+        <span className="flex items-center gap-0.5 text-2xs shrink-0">
           {file.insertions > 0 && (
             <span className="text-success">+{file.insertions}</span>
           )}

--- a/apps/desktop/src/components/source-control/GitHubSetup.tsx
+++ b/apps/desktop/src/components/source-control/GitHubSetup.tsx
@@ -129,7 +129,7 @@ export const GitHubSetup: FC<GitHubSetupProps> = ({ className }) => {
         />
         <div className="flex-1 min-w-0">
           <p className="text-xs font-medium text-foreground">{ghUser.login}</p>
-          <p className="text-[10px] text-muted-foreground/50">Connected</p>
+          <p className="text-2xs text-muted-foreground/60">Connected</p>
         </div>
         <IconButton
           variant="ghost"
@@ -144,7 +144,7 @@ export const GitHubSetup: FC<GitHubSetupProps> = ({ className }) => {
       {/* Create repo form */}
       <div className="space-y-3">
         <div>
-          <label className="text-[10px] font-medium text-muted-foreground/60 uppercase tracking-wider mb-1 block">
+          <label className="text-2xs font-medium text-muted-foreground/60 uppercase tracking-wider mb-1 block">
             Repository Name
           </label>
           <Input

--- a/apps/desktop/src/components/source-control/SourceControlPanel.tsx
+++ b/apps/desktop/src/components/source-control/SourceControlPanel.tsx
@@ -281,7 +281,7 @@ export const SourceControlPanel: FC<SourceControlPanelProps> = ({ className }) =
           </div>
           <div className="space-y-1">
             <p className="text-xs font-medium text-muted-foreground">Not a git repository</p>
-            <p className="text-[11px] text-muted-foreground/50 leading-relaxed">
+            <p className="text-xs text-muted-foreground/60 leading-relaxed">
               Open a folder with a <span className="text-muted-foreground/70">.git</span> directory, or initialize one.
             </p>
           </div>
@@ -300,7 +300,7 @@ export const SourceControlPanel: FC<SourceControlPanelProps> = ({ className }) =
               placeholder="Commit message..."
               className={cn(
                 'w-full h-[72px] px-3 py-2 rounded-lg text-xs resize-none',
-                'bg-muted/40 border-none text-foreground placeholder:text-muted-foreground/50',
+                'bg-muted/40 border-none text-foreground placeholder:text-muted-foreground/60',
                 'focus:bg-muted/60 focus:ring-1 focus:ring-ring/30 focus:outline-none',
                 'transition-colors duration-150',
               )}
@@ -411,7 +411,7 @@ export const SourceControlPanel: FC<SourceControlPanelProps> = ({ className }) =
                 )}
                 Push
                 {commitsAhead != null && commitsAhead > 0 && (
-                  <span className="px-1 py-0.5 rounded-full text-[10px] font-semibold bg-primary/10 text-primary">
+                  <span className="px-1 py-0.5 rounded-full text-2xs font-semibold bg-primary/10 text-primary">
                     {commitsAhead}
                   </span>
                 )}
@@ -462,7 +462,7 @@ export const SourceControlPanel: FC<SourceControlPanelProps> = ({ className }) =
                   Staged Changes
                   <span
                     className={cn(
-                      'ml-1 px-1.5 py-0.5 rounded-full text-[10px] font-semibold',
+                      'ml-1 px-1.5 py-0.5 rounded-full text-2xs font-semibold',
                       'bg-emerald-400/10 text-emerald-400',
                     )}
                   >
@@ -515,7 +515,7 @@ export const SourceControlPanel: FC<SourceControlPanelProps> = ({ className }) =
               {unstagedFiles.length > 0 && (
                 <span
                   className={cn(
-                    'ml-1 px-1.5 py-0.5 rounded-full text-[10px] font-semibold',
+                    'ml-1 px-1.5 py-0.5 rounded-full text-2xs font-semibold',
                     'bg-primary/10 text-primary',
                   )}
                 >
@@ -523,7 +523,7 @@ export const SourceControlPanel: FC<SourceControlPanelProps> = ({ className }) =
                 </span>
               )}
               {changesSummary && (changesSummary.insertions > 0 || changesSummary.deletions > 0) && (
-                <span className="ml-1 flex items-center gap-1 text-[10px]">
+                <span className="ml-1 flex items-center gap-1 text-2xs">
                   {changesSummary.insertions > 0 && (
                     <span className="text-emerald-400">+{changesSummary.insertions}</span>
                   )}
@@ -582,7 +582,7 @@ export const SourceControlPanel: FC<SourceControlPanelProps> = ({ className }) =
                     transition={{ duration: 0.15 }}
                   >
                     <Check className="w-4 h-4 text-muted-foreground/30 mb-0.5" weight="bold" />
-                    <p className="text-[11px] text-muted-foreground/50">No changes detected</p>
+                    <p className="text-xs text-muted-foreground/60">No changes detected</p>
                   </motion.div>
                 ) : (
                   <AnimatedList>

--- a/apps/desktop/src/components/titlebar/WorkspaceSwitcher.tsx
+++ b/apps/desktop/src/components/titlebar/WorkspaceSwitcher.tsx
@@ -131,7 +131,7 @@ export function WorkspaceSwitcher() {
           {dirName(rootPath)}
         </span>
         {activeRepo?.currentBranch && (
-          <span className="text-[10px] text-muted-foreground/60 bg-muted/30 px-1.5 py-0.5 rounded-full truncate max-w-[80px]">
+          <span className="text-2xs text-muted-foreground/60 bg-muted/30 px-1.5 py-0.5 rounded-full truncate max-w-[80px]">
             {activeRepo.currentBranch}
           </span>
         )}
@@ -167,7 +167,7 @@ export function WorkspaceSwitcher() {
                 <div className="text-xs font-medium text-foreground truncate">
                   {dirName(rootPath)}
                 </div>
-                <div className="text-[10px] text-muted-foreground/60 truncate" title={rootPath}>
+                <div className="text-2xs text-muted-foreground/60 truncate" title={rootPath}>
                   {truncatePath(rootPath)}
                 </div>
               </div>
@@ -196,8 +196,8 @@ export function WorkspaceSwitcher() {
           {filteredRecents.length > 0 && (
             <div className="px-1.5 py-1.5 max-h-[200px] overflow-y-auto">
               <div className="flex items-center gap-1.5 px-2 py-1 mb-0.5">
-                <Clock className="w-3 h-3 text-muted-foreground/50" />
-                <span className="text-[10px] font-medium text-muted-foreground/50">Recent</span>
+                <Clock className="w-3 h-3 text-muted-foreground/60" />
+                <span className="text-2xs font-medium text-muted-foreground/60">Recent</span>
               </div>
               {filteredRecents.map((path) => (
                 <button
@@ -208,7 +208,7 @@ export function WorkspaceSwitcher() {
                   <FolderSimple className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
                   <div className="flex-1 min-w-0 text-left">
                     <div className="text-foreground/80 truncate">{dirName(path)}</div>
-                    <div className="text-[10px] text-muted-foreground/50 truncate" title={path}>
+                    <div className="text-2xs text-muted-foreground/60 truncate" title={path}>
                       {truncatePath(path)}
                     </div>
                   </div>

--- a/apps/desktop/src/components/ui/badge.tsx
+++ b/apps/desktop/src/components/ui/badge.tsx
@@ -19,7 +19,7 @@ const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
     <span
       ref={ref}
       className={cn(
-        "inline-flex items-center px-2 py-0.5 rounded-full text-[9px] font-medium",
+        "inline-flex items-center px-2 py-0.5 rounded-full text-2xs font-medium",
         "transition-colors duration-100",
         badgeVariants[variant],
         className

--- a/apps/desktop/src/components/ui/label.tsx
+++ b/apps/desktop/src/components/ui/label.tsx
@@ -9,7 +9,7 @@ const Label = React.forwardRef<
   <LabelPrimitive.Root
     ref={ref}
     className={cn(
-      "text-[10px] font-medium text-foreground/80",
+      "text-2xs font-medium text-foreground/80",
       "peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
       className
     )}

--- a/apps/desktop/src/components/welcome/WelcomeScreen.tsx
+++ b/apps/desktop/src/components/welcome/WelcomeScreen.tsx
@@ -100,7 +100,7 @@ export function WelcomeScreen() {
         <SoloDecryptAnimation />
 
         {/* Tagline */}
-        <p className="text-xs text-muted-foreground/50 tracking-wide mt-4">
+        <p className="text-xs text-muted-foreground/60 tracking-wide mt-4">
           Your AI coding agent
         </p>
 
@@ -121,7 +121,7 @@ export function WelcomeScreen() {
           >
             <FolderOpen className="w-3.5 h-3.5" weight="duotone" />
             Open Project
-            <kbd className="ml-1 text-[10px] opacity-60 font-normal">⌘O</kbd>
+            <kbd className="ml-1 text-2xs opacity-60 font-normal">⌘O</kbd>
           </Button>
           <Button
             variant="secondary"
@@ -146,8 +146,8 @@ export function WelcomeScreen() {
           >
             <div className="rounded-xl bg-card/50 border border-border/30 p-3">
               <div className="flex items-center gap-1.5 mb-2">
-                <Clock className="w-3 h-3 text-muted-foreground/50" />
-                <span className="text-[10px] font-medium text-muted-foreground/50 tracking-wide">
+                <Clock className="w-3 h-3 text-muted-foreground/60" />
+                <span className="text-2xs font-medium text-muted-foreground/60 tracking-wide">
                   Recent Projects
                 </span>
               </div>
@@ -170,7 +170,7 @@ export function WelcomeScreen() {
                     <div className="flex-1 min-w-0 text-left">
                       <div className="text-foreground/80 truncate">{dirName(path)}</div>
                       <div
-                        className="text-[10px] text-muted-foreground/50 truncate"
+                        className="text-2xs text-muted-foreground/60 truncate"
                         title={path}
                       >
                         {truncatePath(path)}
@@ -194,7 +194,7 @@ export function WelcomeScreen() {
 
         {/* Version footer */}
         <div
-          className="absolute bottom-4 text-[10px] text-muted-foreground/30"
+          className="absolute bottom-4 text-2xs text-muted-foreground/40"
           style={{
             opacity: showContent ? 1 : 0,
             transition: 'opacity 400ms var(--ease-smooth) 200ms',

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -117,6 +117,12 @@
 
 }
 
+/* Caption text size (10px/12px) - @utility guarantees class generation */
+@utility text-2xs {
+  font-size: 0.625rem;
+  line-height: 0.75rem;
+}
+
 /* =============================================================================
    LIGHT MODE (default)
    ============================================================================= */


### PR DESCRIPTION
Replace hardcoded pixel font sizes (text-[9px], text-[10px], text-[11px], text-[12.5px]) with semantic Tailwind classes (text-2xs, text-xs, text-sm). Add custom text-2xs utility (10px/12px) for caption-sized text. Bump muted foreground opacity from /50 to /60 across the UI for better light mode readability. Switch dirty worktree indicators from raw yellow to theme-aware warning-foreground token.