### PR TITLE
fix: Move SkillInfo to IPC type binding pipeline

### DIFF
--- a/apps/desktop/src-tauri/src/skills_commands.rs
+++ b/apps/desktop/src-tauri/src/skills_commands.rs
@@ -3,22 +3,10 @@
 //! Scans `~/.solo/skills/` (user-scoped) and `{cwd}/.solo/skills/` (project-scoped)
 //! for markdown skill files, parses their frontmatter, and returns metadata + content.
 
-use serde::Serialize;
+use solo_protocol::{SkillInfo, SkillSource};
 use std::path::{Path, PathBuf};
 use tokio::fs;
 use tracing::debug;
-
-/// Skill information returned to the frontend.
-#[derive(Debug, Clone, Serialize)]
-pub struct SkillInfo {
-    pub name: String,
-    pub description: String,
-    pub content: String,
-    pub source: String, // "user" | "project"
-    pub file_path: String,
-    pub enabled: bool,
-    pub priority: i32,
-}
 
 /// Simple frontmatter parser — extracts key: value pairs from YAML-like header.
 fn parse_frontmatter(raw: &str) -> (std::collections::HashMap<String, String>, String) {
@@ -52,7 +40,7 @@ fn parse_frontmatter(raw: &str) -> (std::collections::HashMap<String, String>, S
 }
 
 /// Scan a single skills directory and return discovered skills.
-async fn discover_skills_in_dir(dir: &Path, scope: &str) -> Vec<SkillInfo> {
+async fn discover_skills_in_dir(dir: &Path, scope: SkillSource) -> Vec<SkillInfo> {
     let mut skills = Vec::new();
 
     let mut entries = match fs::read_dir(dir).await {
@@ -117,7 +105,7 @@ async fn discover_skills_in_dir(dir: &Path, scope: &str) -> Vec<SkillInfo> {
             name,
             description,
             content: body,
-            source: scope.to_string(),
+            source: scope,
             file_path: skill_path.to_string_lossy().into_owned(),
             enabled,
             priority,
@@ -143,7 +131,7 @@ pub async fn skills_list_available(cwd: String) -> Result<Vec<SkillInfo>, String
 
     // User-scoped skills first
     if let Some(user_dir) = user_skills_dir() {
-        let user_skills = discover_skills_in_dir(&user_dir, "user").await;
+        let user_skills = discover_skills_in_dir(&user_dir, SkillSource::User).await;
         for skill in user_skills {
             skill_map.insert(skill.name.clone(), skill);
         }
@@ -151,7 +139,7 @@ pub async fn skills_list_available(cwd: String) -> Result<Vec<SkillInfo>, String
 
     // Project-scoped skills override by name
     let project_dir = PathBuf::from(&cwd).join(".solo").join("skills");
-    let project_skills = discover_skills_in_dir(&project_dir, "project").await;
+    let project_skills = discover_skills_in_dir(&project_dir, SkillSource::Project).await;
     for skill in project_skills {
         skill_map.insert(skill.name.clone(), skill);
     }

--- a/apps/desktop/src/lib/tauri/skills.ts
+++ b/apps/desktop/src/lib/tauri/skills.ts
@@ -5,16 +5,9 @@
  */
 
 import { invoke } from '@tauri-apps/api/core';
+import type { SkillInfo } from '../../bindings/SkillInfo';
 
-export interface SkillInfo {
-  name: string;
-  description: string;
-  content: string;
-  source: 'user' | 'project';
-  file_path: string;
-  enabled: boolean;
-  priority: number;
-}
+export type { SkillInfo };
 
 /**
  * List all available skills from user (~/.solo/skills/) and project ({cwd}/.solo/skills/).

--- a/crates/solo-protocol/src/lib.rs
+++ b/crates/solo-protocol/src/lib.rs
@@ -813,6 +813,32 @@ pub struct ClaudeSetupStatus {
     pub requires_cli_mode: bool,
 }
 
+// =============================================================================
+// Skills Protocol
+// =============================================================================
+
+/// Origin scope of a discovered skill
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "../apps/desktop/src/bindings/")]
+#[serde(rename_all = "snake_case")]
+pub enum SkillSource {
+    User,
+    Project,
+}
+
+/// Skill information returned to the frontend
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "../apps/desktop/src/bindings/")]
+pub struct SkillInfo {
+    pub name: String,
+    pub description: String,
+    pub content: String,
+    pub source: SkillSource,
+    pub file_path: String,
+    pub enabled: bool,
+    pub priority: i32,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- Moves `SkillInfo` struct and new `SkillSource` enum from `skills_commands.rs` into `solo-protocol` with proper `ts-rs` derives
- Replaces hand-written TypeScript `SkillInfo` interface in `skills.ts` with a re-export from the auto-generated binding
- Ensures Rust and TypeScript types stay in sync via the `gen:bindings` pipeline, preventing silent type drift

## Test plan

- [x] `cargo clippy -p solo-protocol` passes
- [x] `cargo check -p solo-desktop` compiles cleanly
- [x] `bun run gen:bindings` generates `SkillInfo.ts` and `SkillSource.ts`
- [x] No skill-related TypeScript errors
- [ ] Verify skills discovery still works at runtime (list available skills in the IDE)