### PR TITLE
Add release pipeline and auto-updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: macos-latest
     permissions:
       contents: write
+    env:
+      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+      APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
 
     steps:
       - name: Checkout
@@ -35,9 +38,8 @@ jobs:
         run: bun install
 
       - name: Import Apple certificate
-        if: ${{ secrets.APPLE_CERTIFICATE != '' }}
+        if: env.APPLE_CERTIFICATE != ''
         env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: |
           CERTIFICATE_PATH=$RUNNER_TEMP/certificate.p12
@@ -60,9 +62,8 @@ jobs:
           security list-keychain -d user -s $KEYCHAIN_PATH
 
       - name: Write Apple API key
-        if: ${{ secrets.APPLE_API_KEY_CONTENT != '' }}
+        if: env.APPLE_API_KEY_CONTENT != ''
         env:
-          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
         run: |
           mkdir -p ~/private_keys
@@ -73,7 +74,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
@@ -89,6 +89,6 @@ jobs:
           args: --target aarch64-apple-darwin
 
       - name: Cleanup keychain
-        if: ${{ always() && secrets.APPLE_CERTIFICATE != '' }}
+        if: always() && env.APPLE_CERTIFICATE != ''
         run: |
           security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true


### PR DESCRIPTION
## Summary
- Add Tauri updater plugin with check/install commands and BackendEvent streaming
- Add in-app update toast notification (New update available / Restart / See changes)
- Add GitHub Actions workflow for ARM64 macOS DMG builds with conditional Apple signing
- Add version bump script and release documentation

## Phase 1 (this PR) — Personal Use
- Unsigned DMG builds via GitHub Actions
- Auto-update via Tauri RSA signing (key already generated)
- Only 1 GitHub secret needed: `TAURI_SIGNING_PRIVATE_KEY`

## Phase 2 (later) — Public Distribution  
- Add Apple Developer secrets for code signing + notarization
- Zero code changes needed — same workflow conditionally enables Apple signing

## Files
- `apps/desktop/src-tauri/src/update_commands.rs` — Rust update commands
- `apps/desktop/src/hooks/useUpdateStream.ts` — Frontend toast hook
- `.github/workflows/release.yml` — CI/CD release pipeline
- `scripts/bump-version.mjs` — Version bump across all manifests
- `docs/RELEASES.md` — Release guide

## Test plan
- [ ] `cargo check` passes with updater plugin
- [ ] Tag push triggers release workflow
- [ ] DMG + updater artifacts produced in draft release
- [ ] Update toast appears when newer version exists