### PR TITLE
feat: Stars background, sidebar redesign, and splash screen

### DIFF
--- a/.claude/skills/solo-ui-skill/animations.md
+++ b/.claude/skills/solo-ui-skill/animations.md
@@ -302,3 +302,35 @@ function Component() {
 // Avoid: Width animation (causes layout shift)
 <div className="w-1/2 transition-[width]" />
 ```
+
+---
+
+## Canvas-Based Animation Pattern
+
+For high-particle-count animations, use `<canvas>` + `requestAnimationFrame` instead of DOM elements.
+Reference: `StarsBackground` (`src/components/ui/stars-background.tsx`).
+
+Key pattern:
+1. `ResizeObserver` for responsive canvas sizing with `devicePixelRatio`
+2. `requestAnimationFrame` loop with delta-time movement
+3. `MutationObserver` on `<html>` for theme-reactive rendering (dark mode only)
+4. `prefers-reduced-motion`: draw one static frame, skip rAF loop
+5. Cleanup: cancel rAF, disconnect observers, remove listeners
+
+### Parallax / Pointer-Tracking
+
+```tsx
+const offsetX = (mouse.x - width / 2) * factor * item.z;
+```
+
+`factor` controls parallax intensity, `z` (0-1) creates depth layers.
+
+---
+
+## RAIL_SPRING Constant
+
+```tsx
+const RAIL_SPRING = { type: 'spring' as const, stiffness: 600, damping: 35 };
+```
+
+Used in: `RepoRail.tsx` (rail width, tooltip transitions).

--- a/.claude/skills/solo-ui-skill/design-system.md
+++ b/.claude/skills/solo-ui-skill/design-system.md
@@ -190,6 +190,47 @@ shadow-[0_4px_12px_-4px_rgba(0,0,0,0.2)]
 </button>
 ```
 
+### StarsBackground (Canvas)
+
+```tsx
+// Dark-mode-only animated star field with parallax
+import { StarsBackground } from '@/components/ui/stars-background';
+
+<StarsBackground
+  className="absolute inset-0 z-0"
+  count={150}
+  speed={30}
+  starColor="rgba(255,255,255,0.6)"
+  pointerEvents={false}
+/>
+```
+
+Props: `count`, `factor` (parallax), `speed`, `starColor`, `pointerEvents`, `className`.
+Auto-hides in light mode via `MutationObserver` on `html.dark`. Respects `prefers-reduced-motion`.
+
+### LayoutId Sliding Indicator
+
+Used in ModeToggle and StudioSidebar for smooth active-state transitions:
+
+```tsx
+{isActive && (
+  <motion.div
+    layoutId="indicator-id"
+    className="absolute inset-0 rounded-xl bg-primary/10"
+    transition={{ type: 'spring', stiffness: 500, damping: 35 }}
+  />
+)}
+<span className="relative">{label}</span>
+```
+
+### Sidebar Spacing Conventions
+
+- Header height: `h-10` (40px)
+- Section header height: `h-8` (32px)
+- Section header text: `text-[11px] text-muted-foreground/50 font-semibold`
+- Repo name: `text-[13px] font-semibold tracking-tight`
+- Mode toggle margins: `mx-3 my-2.5`
+
 ---
 
 ## Opacity Patterns

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -61,6 +61,14 @@ function AppContent() {
   // Tab switcher (Cmd+Shift+T)
   const [tabSwitcherOpen, setTabSwitcherOpen] = useState(false);
 
+  // Splash screen — guarantee WelcomeScreen is visible for at least 5s
+  const [splashComplete, setSplashComplete] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setSplashComplete(true), 5000);
+    return () => clearTimeout(timer);
+  }, []);
+
   // Terminal panel drag state
   const [isDraggingTerminal, setIsDraggingTerminal] = useState(false);
   const dragStartY = useRef<number>(0);
@@ -407,7 +415,7 @@ function AppContent() {
         className="absolute top-0 inset-x-0 h-[38px] flex items-center z-50 bg-background titlebar-glass border-b border-border/20"
       >
         <div className="flex-1 flex items-center gap-1.5 ml-1.5" data-tauri-drag-region>
-          {(rootPath !== null || hasRepos) && (
+          {splashComplete && (rootPath !== null || hasRepos) && (
             <button
               onClick={toggleSidebar}
               className={cn(
@@ -441,7 +449,7 @@ function AppContent() {
               {user.email}
             </span>
           )}
-          {(rootPath !== null || hasRepos) && (
+          {splashComplete && (rootPath !== null || hasRepos) && (
             <TitlebarButton
               onClick={handleToggleTerminal}
               icon={<Terminal className={cn('w-4 h-4', terminalPanelOpen ? 'text-primary' : 'text-muted-foreground')} />}
@@ -494,23 +502,27 @@ function AppContent() {
             className="flex h-full"
           >
             <DndProvider backend={HTML5Backend}>
-              {/* Repo icon rail - always visible when repos exist */}
-              {hasRepos && <RepoRail />}
+              {/* Repo icon rail - always visible when repos exist (hidden during splash) */}
+              {splashComplete && hasRepos && <RepoRail />}
 
-              {/* Content sidebar - collapsible */}
-              <PrimarySidebar ref={sidebarRef} width={leftSidebarWidth} onFileOpen={handleFileOpen} />
+              {/* Content sidebar - collapsible (hidden during splash) */}
+              {splashComplete && (
+                <>
+                  <PrimarySidebar ref={sidebarRef} width={leftSidebarWidth} onFileOpen={handleFileOpen} />
 
-              <div
-                className="split-divider"
-                onPointerDown={handlePointerDown}
-                onPointerMove={handlePointerMove}
-                onPointerUp={handlePointerUp}
-                onDoubleClick={handleDoubleClick}
-              />
+                  <div
+                    className="split-divider"
+                    onPointerDown={handlePointerDown}
+                    onPointerMove={handlePointerMove}
+                    onPointerUp={handlePointerUp}
+                    onDoubleClick={handleDoubleClick}
+                  />
+                </>
+              )}
 
               {/* Right column: editor area or welcome */}
               <div className="flex-1 flex flex-col overflow-hidden min-h-0 pt-[38px] bg-background">
-                {rootPath !== null || sidebarMode === 'studio' ? (
+                {splashComplete && (rootPath !== null || sidebarMode === 'studio') ? (
                   <>
                     <div className="flex-1 overflow-hidden min-h-0">
                       <MosaicLayout />
@@ -543,7 +555,7 @@ function AppContent() {
                     </div>
                   </>
                 ) : (
-                  <WelcomeScreen />
+                  <WelcomeScreen onProjectOpen={() => setSplashComplete(true)} />
                 )}
               </div>
             </DndProvider>

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -61,13 +61,8 @@ function AppContent() {
   // Tab switcher (Cmd+Shift+T)
   const [tabSwitcherOpen, setTabSwitcherOpen] = useState(false);
 
-  // Splash screen — guarantee WelcomeScreen is visible for at least 5s
+  // Splash gate — WelcomeScreen stays until user picks a project
   const [splashComplete, setSplashComplete] = useState(false);
-
-  useEffect(() => {
-    const timer = setTimeout(() => setSplashComplete(true), 5000);
-    return () => clearTimeout(timer);
-  }, []);
 
   // Terminal panel drag state
   const [isDraggingTerminal, setIsDraggingTerminal] = useState(false);

--- a/apps/desktop/src/components/sidebar/DevSidebar.tsx
+++ b/apps/desktop/src/components/sidebar/DevSidebar.tsx
@@ -117,8 +117,8 @@ export const DevSidebar: FC<DevSidebarProps> = ({ onFileOpen }) => {
             className="flex-1 flex flex-col min-h-0"
           >
             {/* Section header */}
-            <div className="flex items-center justify-between px-3 h-7 shrink-0">
-              <span className="text-[10px] uppercase tracking-wider text-muted-foreground/80 font-medium">
+            <div className="flex items-center justify-between px-3 h-8 shrink-0">
+              <span className="text-[11px] text-muted-foreground/50 font-semibold">
                 Worktrees
               </span>
               <div className="flex items-center gap-0.5">
@@ -148,37 +148,46 @@ export const DevSidebar: FC<DevSidebarProps> = ({ onFileOpen }) => {
             </div>
 
             {/* Create form */}
-            {showCreate && (
-              <div className="mx-2 mb-1 px-3 py-2 rounded-lg bg-muted/20 border border-border/20 space-y-2">
-                <input
-                  type="text"
-                  placeholder="Branch name"
-                  value={branchName}
-                  onChange={(e) => setBranchName(e.target.value)}
-                  onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
-                  className="w-full h-7 px-2 text-xs bg-muted/30 border border-border/50 rounded outline-none focus:ring-1 focus:ring-ring"
-                  autoFocus
-                />
-                <div className="flex items-center gap-2">
-                  <button
-                    onClick={handleCreate}
-                    disabled={!branchName.trim() || isCreating}
-                    className="h-6 px-3 text-xs bg-primary text-primary-foreground rounded hover:bg-primary/90 disabled:opacity-50"
-                  >
-                    {isCreating ? 'Creating...' : 'Create'}
-                  </button>
-                  <button
-                    onClick={() => setShowCreate(false)}
-                    className="h-6 px-3 text-xs text-muted-foreground hover:text-foreground"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </div>
-            )}
+            <AnimatePresence>
+              {showCreate && (
+                <motion.div
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: 'auto' }}
+                  exit={{ opacity: 0, height: 0 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  <div className="mx-2 mb-1 px-3 py-2 rounded-lg bg-muted/20 border border-border/20 space-y-2">
+                    <input
+                      type="text"
+                      placeholder="Branch name"
+                      value={branchName}
+                      onChange={(e) => setBranchName(e.target.value)}
+                      onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+                      className="w-full h-7 px-2 text-xs bg-muted/30 border border-border/50 rounded outline-none focus:ring-1 focus:ring-ring"
+                      autoFocus
+                    />
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={handleCreate}
+                        disabled={!branchName.trim() || isCreating}
+                        className="h-6 px-3 text-xs bg-primary text-primary-foreground rounded hover:bg-primary/90 disabled:opacity-50"
+                      >
+                        {isCreating ? 'Creating...' : 'Create'}
+                      </button>
+                      <button
+                        onClick={() => setShowCreate(false)}
+                        className="h-6 px-3 text-xs text-muted-foreground hover:text-foreground"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
 
             {/* Worktree cards */}
-            <div className="flex-1 overflow-y-auto py-1">
+            <div className="flex-1 overflow-y-auto py-1.5">
               {worktrees.length === 0 ? (
                 <div className="flex flex-col items-center justify-center py-8 text-center px-4">
                   <div className="w-10 h-10 rounded-2xl bg-muted/50 flex items-center justify-center mb-2">

--- a/apps/desktop/src/components/sidebar/ModeToggle.tsx
+++ b/apps/desktop/src/components/sidebar/ModeToggle.tsx
@@ -18,8 +18,8 @@ export const ModeToggle: FC = () => {
   const setSidebarMode = useUIStore((s) => s.setSidebarMode);
 
   return (
-    <div className="mx-2.5 my-2">
-      <div className="relative flex h-8 rounded-lg bg-muted/30 p-0.5">
+    <div className="mx-3 my-2.5">
+      <div className="relative flex h-8 rounded-lg bg-muted/30 p-0.5 border border-border/10">
         {MODES.map(({ key, label }) => (
           <button
             key={key}
@@ -27,14 +27,14 @@ export const ModeToggle: FC = () => {
             className={cn(
               'relative z-10 flex-1 text-xs font-medium rounded-md transition-colors duration-150',
               sidebarMode === key
-                ? 'text-primary'
+                ? 'text-primary font-semibold'
                 : 'text-muted-foreground hover:text-foreground',
             )}
           >
             {sidebarMode === key && (
               <motion.div
                 layoutId="mode-indicator"
-                className="absolute inset-0 rounded-md bg-primary/10"
+                className="absolute inset-0 rounded-md bg-primary/10 shadow-sm"
                 transition={{ type: 'spring', stiffness: 500, damping: 35 }}
               />
             )}

--- a/apps/desktop/src/components/sidebar/PrimarySidebar.tsx
+++ b/apps/desktop/src/components/sidebar/PrimarySidebar.tsx
@@ -5,12 +5,12 @@
  */
 
 import { useCallback, forwardRef } from 'react';
+import { motion } from 'motion/react';
 import { FolderPlus as FolderPlusIcon } from '@phosphor-icons/react';
 import { ModeToggle } from './ModeToggle';
 import { DevSidebar } from './DevSidebar';
 import { StudioSidebar } from './StudioSidebar';
 import { SidebarHeader } from './SidebarHeader';
-import { TRANSITIONS } from '@/lib/constants';
 import { useUIStore, useIsLeftSidebarCollapsed } from '@/stores/uiStore';
 import { useRepoStore, useRepoList } from '@/stores/repoStore';
 import { openFolderDialog } from '@/lib/tauri/fs';
@@ -40,14 +40,15 @@ export const PrimarySidebar = forwardRef<HTMLElement, PrimarySidebarProps>(({ wi
     }
   }, [addRepo]);
 
+  const isResizing = typeof document !== 'undefined' && document.body.classList.contains('is-resizing');
+
   return (
-    <aside
+    <motion.aside
       ref={ref}
       className="h-full flex flex-col relative bg-sidebar overflow-hidden pt-[38px]"
-      style={{
-        width,
-        transition: `width ${TRANSITIONS.sidebar}`,
-      }}
+      animate={{ width }}
+      transition={isResizing ? { duration: 0 } : { type: 'spring', stiffness: 400, damping: 30 }}
+      style={{ width }}
     >
       {/* Loading overlay during repo switch */}
       {isSwitching && (
@@ -68,8 +69,13 @@ export const PrimarySidebar = forwardRef<HTMLElement, PrimarySidebarProps>(({ wi
           {/* Content area */}
           {repos.length === 0 ? (
             /* Empty state - no repos */
-            <div className="flex-1 flex flex-col items-center justify-center gap-3 px-4 text-center">
-              <div className="w-10 h-10 rounded-xl bg-muted/40 flex items-center justify-center">
+            <motion.div
+              className="flex-1 flex flex-col items-center justify-center gap-3 px-4 text-center"
+              initial={{ opacity: 0, scale: 0.96 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ duration: 0.3 }}
+            >
+              <div className="w-12 h-12 rounded-2xl bg-muted/40 flex items-center justify-center">
                 <FolderPlusIcon className="w-5 h-5 text-muted-foreground/50" />
               </div>
               <div>
@@ -82,7 +88,7 @@ export const PrimarySidebar = forwardRef<HTMLElement, PrimarySidebarProps>(({ wi
               >
                 Add Repository
               </button>
-            </div>
+            </motion.div>
           ) : (
             <>
               <ModeToggle />
@@ -95,6 +101,6 @@ export const PrimarySidebar = forwardRef<HTMLElement, PrimarySidebarProps>(({ wi
           )}
         </>
       )}
-    </aside>
+    </motion.aside>
   );
 });

--- a/apps/desktop/src/components/sidebar/RepoRail.tsx
+++ b/apps/desktop/src/components/sidebar/RepoRail.tsx
@@ -103,6 +103,8 @@ export const RepoRail: FC = () => {
         </button>
       </div>
 
+      <div className="h-px mx-2 bg-border/10 my-1" />
+
       {/* Repo list */}
       <div
         className={cn(
@@ -161,6 +163,8 @@ const RailIcon: FC<RailIconProps> = ({ repo, isActive, expanded, onClick, onRemo
                 layoutId="rail-accent"
                 className="absolute left-0 top-1/2 -translate-y-1/2 w-[3px] h-5 rounded-r-full z-10"
                 style={{ backgroundColor: getRepoColorVar(repo.color) }}
+                initial={{ scaleY: 0 }}
+                animate={{ scaleY: 1 }}
                 transition={{ type: 'spring', stiffness: 500, damping: 30 }}
               />
             )}
@@ -244,6 +248,8 @@ const RailIcon: FC<RailIconProps> = ({ repo, isActive, expanded, onClick, onRemo
               layoutId="rail-accent"
               className="absolute left-0 top-1/2 -translate-y-1/2 w-[3px] h-5 rounded-r-full"
               style={{ backgroundColor: getRepoColorVar(repo.color) }}
+              initial={{ scaleY: 0 }}
+              animate={{ scaleY: 1 }}
               transition={{ type: 'spring', stiffness: 500, damping: 30 }}
             />
           )}
@@ -284,7 +290,7 @@ const RailIcon: FC<RailIconProps> = ({ repo, isActive, expanded, onClick, onRemo
                 initial={{ opacity: 0, x: -4 }}
                 animate={{ opacity: 1, x: 0 }}
                 exit={{ opacity: 0, x: -4 }}
-                transition={{ duration: 0.15 }}
+                transition={{ type: 'spring', stiffness: 500, damping: 30 }}
                 className={cn(
                   'absolute left-full ml-2 z-50 pointer-events-none',
                   'px-2.5 py-1.5 rounded-lg',

--- a/apps/desktop/src/components/sidebar/SidebarHeader.tsx
+++ b/apps/desktop/src/components/sidebar/SidebarHeader.tsx
@@ -30,7 +30,7 @@ export const SidebarHeader: FC = () => {
   if (!activeRepo) return null;
 
   return (
-    <div className="relative flex items-center gap-2 h-9 px-2.5 shrink-0 border-b border-border/10">
+    <div className="relative flex items-center gap-2 h-10 px-2.5 shrink-0 border-b border-border/15">
       {/* Repo icon (colored) */}
       {Icon && (
         <Icon
@@ -41,7 +41,7 @@ export const SidebarHeader: FC = () => {
       )}
 
       {/* Repo name */}
-      <span className="text-xs font-semibold truncate">
+      <span className="text-[13px] font-semibold tracking-tight truncate">
         {activeRepo.name}
       </span>
 
@@ -51,7 +51,7 @@ export const SidebarHeader: FC = () => {
           onClick={() => setSwitcherOpen((v) => !v)}
           className={cn(
             'flex items-center gap-1 h-5 px-1.5 rounded-md',
-            'text-[10px] text-muted-foreground bg-muted/30',
+            'text-[10px] text-muted-foreground bg-muted/40',
             'hover:bg-muted/60 hover:text-foreground',
             'active:scale-[0.97] transition-all duration-150',
             'ml-auto shrink-0 max-w-[100px]',

--- a/apps/desktop/src/components/sidebar/StudioSidebar.tsx
+++ b/apps/desktop/src/components/sidebar/StudioSidebar.tsx
@@ -4,6 +4,7 @@
  */
 
 import type { FC } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
 import { ChatTeardrop, Vault, Lightning, PenNib } from '@phosphor-icons/react';
 import { SessionList } from '@/components/agent';
 import { VaultPlaceholder } from './studio/VaultPlaceholder';
@@ -57,16 +58,23 @@ export const StudioSidebar: FC = () => {
             key={key}
             onClick={() => setStudioNav(key)}
             className={cn(
-              'w-full h-9 px-3 flex items-center gap-2 rounded-lg text-xs transition-colors duration-150',
+              'relative w-full h-9 px-3 flex items-center gap-2 rounded-xl text-xs transition-colors duration-150',
               studioActiveNav === key
-                ? 'bg-primary/10 text-primary'
+                ? 'text-primary'
                 : 'text-muted-foreground hover:bg-muted/40 hover:text-foreground',
             )}
           >
-            <Icon className="w-4 h-4 shrink-0" weight={studioActiveNav === key ? 'fill' : 'regular'} />
-            <span className="flex-1 text-left font-medium">{label}</span>
+            {studioActiveNav === key && (
+              <motion.div
+                layoutId="studio-nav-indicator"
+                className="absolute inset-0 rounded-xl bg-primary/10"
+                transition={{ type: 'spring', stiffness: 500, damping: 35 }}
+              />
+            )}
+            <Icon className="relative w-4 h-4 shrink-0" weight={studioActiveNav === key ? 'fill' : 'regular'} />
+            <span className="relative flex-1 text-left font-medium">{label}</span>
             {badge && (
-              <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-muted/50 text-muted-foreground/70 font-medium">
+              <span className="relative text-[9px] px-1.5 py-0.5 rounded-full bg-primary/8 text-primary/60 font-medium">
                 {badge}
               </span>
             )}
@@ -75,7 +83,7 @@ export const StudioSidebar: FC = () => {
       </div>
 
       {/* Divider */}
-      <div className="h-px mx-3 bg-border/20 shrink-0" />
+      <div className="h-px mx-3 shrink-0" style={{ background: 'linear-gradient(to right, transparent, var(--border) 20%, var(--border) 80%, transparent)', opacity: 0.15 }} />
 
       {/* Content area */}
       <div className="flex-1 min-h-0 overflow-hidden">

--- a/apps/desktop/src/components/ui/stars-background.tsx
+++ b/apps/desktop/src/components/ui/stars-background.tsx
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface Star {
+  x: number;
+  y: number;
+  z: number;
+  size: number;
+}
+
+interface StarsBackgroundProps extends React.CanvasHTMLAttributes<HTMLCanvasElement> {
+  count?: number;
+  factor?: number;
+  speed?: number;
+  starColor?: string;
+  pointerEvents?: boolean;
+  className?: string;
+}
+
+function createStars(count: number, width: number, height: number): Star[] {
+  const stars: Star[] = [];
+  for (let i = 0; i < count; i++) {
+    stars.push({
+      x: Math.random() * width,
+      y: Math.random() * height,
+      z: Math.random(),
+      size: 0.5 + Math.random() * 2,
+    });
+  }
+  return stars;
+}
+
+export function StarsBackground({
+  count = 200,
+  factor = 0.05,
+  speed = 50,
+  starColor = "#fff",
+  pointerEvents = true,
+  className,
+  ...props
+}: StarsBackgroundProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const starsRef = useRef<Star[]>([]);
+  const mouseRef = useRef({ x: 0, y: 0 });
+  const rafRef = useRef<number>(0);
+  const [isDark, setIsDark] = useState(() =>
+    document.documentElement.classList.contains("dark")
+  );
+
+  const drawStars = useCallback(
+    (ctx: CanvasRenderingContext2D, width: number, height: number) => {
+      ctx.clearRect(0, 0, width, height);
+      const mx = mouseRef.current.x;
+      const my = mouseRef.current.y;
+
+      for (const star of starsRef.current) {
+        const offsetX = (mx - width / 2) * factor * star.z;
+        const offsetY = (my - height / 2) * factor * star.z;
+        const sx = star.x + offsetX;
+        const sy = star.y + offsetY;
+
+        ctx.globalAlpha = 0.3 + 0.7 * star.z;
+        ctx.fillStyle = starColor;
+        ctx.beginPath();
+        ctx.arc(sx, sy, star.size * (0.5 + 0.5 * star.z), 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.globalAlpha = 1;
+    },
+    [factor, starColor]
+  );
+
+  useEffect(() => {
+    const html = document.documentElement;
+    const observer = new MutationObserver(() => {
+      setIsDark(html.classList.contains("dark"));
+    });
+    observer.observe(html, { attributes: true, attributeFilter: ["class"] });
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!isDark) return;
+
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const parent = canvas.parentElement ?? document.body;
+
+    const resize = () => {
+      const rect = parent.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      canvas.style.width = `${rect.width}px`;
+      canvas.style.height = `${rect.height}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      starsRef.current = createStars(count, rect.width, rect.height);
+    };
+
+    resize();
+
+    const resizeObserver = new ResizeObserver(resize);
+    resizeObserver.observe(parent);
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      mouseRef.current = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    };
+    canvas.addEventListener("mousemove", handleMouseMove);
+
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches;
+
+    if (prefersReducedMotion) {
+      drawStars(ctx, canvas.width / (window.devicePixelRatio || 1), canvas.height / (window.devicePixelRatio || 1));
+      return () => {
+        canvas.removeEventListener("mousemove", handleMouseMove);
+        resizeObserver.disconnect();
+      };
+    }
+
+    let lastTime = 0;
+
+    const animate = (time: number) => {
+      const delta = lastTime ? (time - lastTime) / 1000 : 0;
+      lastTime = time;
+
+      const w = canvas.width / (window.devicePixelRatio || 1);
+      const h = canvas.height / (window.devicePixelRatio || 1);
+
+      for (const star of starsRef.current) {
+        star.y += delta * speed * (0.2 + 0.8 * star.z);
+        if (star.y > h + star.size) {
+          star.y = -star.size;
+          star.x = Math.random() * w;
+        }
+      }
+
+      drawStars(ctx, w, h);
+      rafRef.current = requestAnimationFrame(animate);
+    };
+
+    rafRef.current = requestAnimationFrame(animate);
+
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      canvas.removeEventListener("mousemove", handleMouseMove);
+      resizeObserver.disconnect();
+    };
+  }, [isDark, count, speed, factor, starColor, drawStars]);
+
+  if (!isDark) return null;
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={className}
+      style={{ pointerEvents: pointerEvents ? "auto" : "none" }}
+      {...props}
+    />
+  );
+}

--- a/apps/desktop/src/components/welcome/WelcomeScreen.tsx
+++ b/apps/desktop/src/components/welcome/WelcomeScreen.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect } from 'react';
 import { FolderOpen, GitBranch, Clock, FolderSimple, X } from '@phosphor-icons/react';
 import { Button, IconButton } from '@solo/ui';
 import SoloDecryptAnimation from '../agent/SoloDecryptAnimation';
+import { StarsBackground } from '@/components/ui/stars-background';
 import { CloneDialog } from './CloneDialog';
 import { openFolderDialog } from '@/lib/tauri/fs';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
@@ -85,9 +86,18 @@ export function WelcomeScreen() {
   return (
     <>
       <div className="relative bg-background flex-1 flex flex-col items-center justify-center h-full overflow-hidden select-none">
+        {/* Animated stars background (dark mode only) */}
+        <StarsBackground
+          className="absolute inset-0 z-0"
+          count={150}
+          speed={30}
+          starColor="rgba(255,255,255,0.6)"
+          pointerEvents={false}
+        />
+
         {/* Animated glow — breathes continuously while welcome screen is visible */}
         <div
-          className="absolute top-[30%] left-1/2 rounded-full pointer-events-none startup-glow"
+          className="absolute top-[30%] left-1/2 rounded-full pointer-events-none startup-glow z-[1]"
           style={{
             width: 300,
             height: 300,
@@ -100,13 +110,13 @@ export function WelcomeScreen() {
         <SoloDecryptAnimation />
 
         {/* Tagline */}
-        <p className="text-xs text-muted-foreground/50 tracking-wide mt-4">
+        <p className="relative z-10 text-xs text-muted-foreground/50 tracking-wide mt-4">
           Your AI coding agent
         </p>
 
         {/* Action buttons — fade in after decrypt assembles */}
         <div
-          className="flex items-center gap-3 mt-8"
+          className="relative z-10 flex items-center gap-3 mt-8"
           style={{
             opacity: showContent ? 1 : 0,
             transform: showContent ? 'translateY(0)' : 'translateY(8px)',
@@ -137,7 +147,7 @@ export function WelcomeScreen() {
         {/* Recent Projects — staggered fade-in */}
         {recentDirectories.length > 0 && (
           <div
-            className="mt-8 w-full max-w-sm"
+            className="relative z-10 mt-8 w-full max-w-sm"
             style={{
               opacity: showContent ? 1 : 0,
               transform: showContent ? 'translateY(0)' : 'translateY(8px)',

--- a/apps/desktop/src/components/welcome/WelcomeScreen.tsx
+++ b/apps/desktop/src/components/welcome/WelcomeScreen.tsx
@@ -24,7 +24,11 @@ const truncatePath = (p: string, maxLen = 50) => {
   return `...${sep}${parts.slice(-3).join(sep)}`;
 };
 
-export function WelcomeScreen() {
+interface WelcomeScreenProps {
+  onProjectOpen?: () => void;
+}
+
+export function WelcomeScreen({ onProjectOpen }: WelcomeScreenProps = {}) {
   const recentDirectories = useWorkspaceStore((s) => s.recentDirectories);
   const removeRecent = useWorkspaceStore((s) => s.removeRecent);
   const [cloneOpen, setCloneOpen] = useState(false);
@@ -52,15 +56,17 @@ export function WelcomeScreen() {
   const handleOpenProject = useCallback(async () => {
     const path = await openFolderDialog();
     if (path) {
+      onProjectOpen?.();
       await openOrSelectRepo(path);
     }
-  }, [openOrSelectRepo]);
+  }, [openOrSelectRepo, onProjectOpen]);
 
   const handleSwitchTo = useCallback(
     async (path: string) => {
+      onProjectOpen?.();
       await openOrSelectRepo(path);
     },
-    [openOrSelectRepo],
+    [openOrSelectRepo, onProjectOpen],
   );
 
   const handleRemoveRecent = useCallback(

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -891,6 +891,13 @@ html.dark .hover-lift:hover {
   animation: streaming-dot 1.2s ease-in-out infinite;
 }
 
+/* Sidebar gradient separator — fades at edges */
+.sidebar-section-separator {
+  height: 1px;
+  background: linear-gradient(to right, transparent, var(--border) 20%, var(--border) 80%, transparent);
+  opacity: 0.15;
+}
+
 
 /* =============================================================================
    STREAMDOWN THEME OVERRIDES

--- a/docs/DESIGN-CHANGELOG.md
+++ b/docs/DESIGN-CHANGELOG.md
@@ -1,0 +1,25 @@
+# Design Changelog
+
+## 2026-03-06 — Stars Background + Sidebar Redesign
+
+### Stars Background (WelcomeScreen)
+- Added canvas-based `StarsBackground` component with parallax mouse tracking
+- Integrated into WelcomeScreen as first layer (z-0), glow bumped to z-1, content to z-10
+- Dark mode only — auto-hides in light mode via MutationObserver
+- Respects `prefers-reduced-motion` (static frame, no animation loop)
+- Props: count=150, speed=30, starColor=rgba(255,255,255,0.6)
+
+### Sidebar Visual Refinements
+- **SidebarHeader**: height h-9 to h-10, repo name text-[13px] tracking-tight, border-border/15
+- **ModeToggle**: mx-3 my-2.5 spacing, border border-border/10, shadow-sm on active indicator, font-semibold active label
+- **PrimarySidebar**: motion.aside with spring-animated width (disabled during drag), larger empty state icon (w-12 h-12 rounded-2xl), entry animation on empty state
+- **RepoRail**: separator between add button and repo list, scaleY entrance on accent bar, spring tooltip transition
+- **DevSidebar**: section header text-[11px] font-semibold (removed uppercase), h-8 height, AnimatePresence on create form, py-1.5 scroll padding
+- **StudioSidebar**: layoutId sliding nav indicator, rounded-xl nav items, bg-primary/8 "Soon" badge, gradient fade divider
+
+### CSS Utilities
+- Added `.sidebar-section-separator` gradient utility class
+
+### Documentation
+- Updated design-system.md with StarsBackground, layoutId indicator, and sidebar spacing conventions
+- Updated animations.md with canvas-based animation pattern, parallax docs, RAIL_SPRING constant


### PR DESCRIPTION
## Summary

- **Stars background**: Canvas-based animated star field on WelcomeScreen with parallax mouse tracking (dark mode only, respects `prefers-reduced-motion`)
- **Sidebar visual refinements**: Updated spacing, typography, animated indicators across SidebarHeader, ModeToggle, PrimarySidebar, RepoRail, DevSidebar, and StudioSidebar
- **Splash screen gate**: WelcomeScreen stays visible until user actively selects a project — sidebar, rail, and workspace-specific UI hidden during splash

## Test plan

- [ ] Launch app — WelcomeScreen with stars + glow + decrypt animation + sound is visible
- [ ] Move mouse over welcome screen — confirm parallax effect on stars
- [ ] WelcomeScreen stays until user clicks "Open Project" or selects a recent project
- [ ] After selecting a project, sidebar/rail/workspace appear with the selected project loaded
- [ ] Open a project — sidebar renders with updated spacing/typography
- [ ] Toggle Dev/Studio mode — confirm animated indicator slides smoothly
- [ ] Expand/collapse RepoRail — confirm smooth spring animations
- [ ] Test with `prefers-reduced-motion` — stars render statically
- [ ] Light mode — stars background hidden, everything else works