### PR TITLE
chore: rebuild agent-bridge dist

### DIFF
--- a/agent-bridge/dist/index.js
+++ b/agent-bridge/dist/index.js
@@ -3000,4 +3000,3 @@ try {
   logger9.error({ error }, "Fatal error");
   process.exit(1);
 }
-//# sourceMappingURL=index.js.map


### PR DESCRIPTION
## Summary

Follow-up to PR #112 (now merged). That PR wired `agent-bridge` into the bun workspace and added a `postinstall` hook to rebuild `agent-bridge/dist/index.js`. This PR captures the rebuilt artifact so the tracked `dist/` file matches what the new build step produces — matching the repo's existing convention set by commit `e74652b4 "Rebuild agent-bridge dist after dev merge"`.

## What changed

- `agent-bridge/dist/index.js` — 1-line regen from the postinstall hook

## Why it's separate from #112

The rebuilt dist was pushed to `claude/distracted-babbage` after #112's merge had already started, so it missed the merge. Rather than force-push the already-merged branch, this is a small follow-up PR from a fresh branch off `dev`.

## Test plan

- [ ] CI passes
- [ ] Diff is limited to `agent-bridge/dist/index.js`