### PR TITLE
[codex] Add workspace and worktree keyboard shortcuts

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -9,6 +9,7 @@ import { SidebarTerminal } from "./components/sidebar";
 import { MosaicLayout } from "./components/panels";
 import { AuthGuard } from "./components/auth";
 import { useUIStore, useIsLeftSidebarCollapsed } from "./stores/uiStore";
+import { usePanelLayoutStore } from "./stores/panelLayoutStore";
 import { usePanelTabsStore } from "./stores/panelTabsStore";
 import { useProviderStore } from "./stores/provider-store";
 import { useAgentStore } from "./stores/agentStore";
@@ -43,6 +44,7 @@ import { KeyboardShortcutsOverlay } from "./components/KeyboardShortcutsOverlay"
 import { BugReportDialog } from "./components/bug-report/BugReportDialog";
 import { TabSwitcher } from "./components/panels/TabSwitcher";
 import { SkillsOnboardingDialog } from "./components/agent/SkillsOnboardingDialog";
+import { getEffectiveKeybinding, matchesKeybinding } from "./lib/keybindings";
 
 // Shared easing curve matching --ease-smooth
 const EASE_SMOOTH: [number, number, number, number] = [0.16, 1, 0.3, 1];
@@ -91,6 +93,7 @@ function AppContent() {
   const rootPath = useFileExplorerStore((s) => s.rootPath);
   const hasRepos = useRepoStore((s) => s.repos.size > 0);
   const sidebarMode = useUIStore((s) => s.sidebarMode);
+  const customKeybindings = useSettingsStore((s) => s.shortcuts.keybindings);
 
   // Get openPanel action directly from store to avoid selector subscription issues
   const openPanel = useMemo(() => usePanelTabsStore.getState().openPanel, []);
@@ -202,53 +205,147 @@ function AppContent() {
     uiState.toggleTerminalPanel();
   }, []);
 
+  const handleCreateTerminal = useCallback(() => {
+    const cwd = useFileExplorerStore.getState().rootPath ?? undefined;
+
+    if (!useUIStore.getState().terminalPanelOpen) {
+      useUIStore.getState().toggleTerminalPanel();
+    }
+
+    createTerminal(cwd)
+      .then(({ id, shell }) => {
+        useTerminalStore.getState().addTerminal(id, cwd, shell);
+      })
+      .catch((err) => console.error('Failed to create terminal:', err));
+  }, []);
+
+  const handleCycleWorkspace = useCallback((direction: 'next' | 'prev') => {
+    const { repos, activeRepoPath } = useRepoStore.getState();
+    const repoList = Array.from(repos.values());
+
+    if (repoList.length < 2) return;
+
+    const currentIndex = activeRepoPath
+      ? repoList.findIndex((repo) => repo.path === activeRepoPath)
+      : -1;
+
+    const nextIndex = currentIndex === -1
+      ? 0
+      : direction === 'next'
+        ? (currentIndex + 1) % repoList.length
+        : (currentIndex - 1 + repoList.length) % repoList.length;
+
+    const targetRepo = repoList[nextIndex];
+    if (!targetRepo) return;
+
+    void useRepoStore.getState().selectWorktree(targetRepo.path, null);
+  }, []);
+
+  const handleSwitchWorktreeSlot = useCallback(async (slotIndex: number) => {
+    const repoStore = useRepoStore.getState();
+    const activeRepoPath = repoStore.activeRepoPath;
+    if (!activeRepoPath) return;
+
+    let repo = repoStore.repos.get(activeRepoPath);
+    if (!repo) return;
+
+    if (!repo._worktreesLoaded) {
+      await repoStore.refreshWorktrees(activeRepoPath);
+      repo = useRepoStore.getState().repos.get(activeRepoPath);
+      if (!repo) return;
+    }
+
+    const orderedWorktreeIds = [
+      null,
+      ...repo.worktrees.filter((worktree) => !worktree.is_main).map((worktree) => worktree.id),
+    ];
+
+    const targetWorktreeId = orderedWorktreeIds[slotIndex];
+    if (targetWorktreeId === undefined) return;
+
+    await repoStore.selectWorktree(activeRepoPath, targetWorktreeId);
+  }, []);
+
+  const matchAction = useCallback(
+    (actionId: string, e: KeyboardEvent) => {
+      const keybinding = getEffectiveKeybinding(actionId, customKeybindings);
+      return Boolean(keybinding) && matchesKeybinding(keybinding, e);
+    },
+    [customKeybindings]
+  );
+
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Cmd+= / Cmd++ — zoom in (accept both the unshifted '=' and shifted '+')
-      if ((e.key === '=' || e.key === '+') && e.metaKey && !e.ctrlKey && !e.altKey) {
+      const isEditorFocused = Boolean(document.activeElement?.closest('.monaco-editor'));
+      const isTerminalOpen = useUIStore.getState().terminalPanelOpen;
+      const targetTileId = usePanelLayoutStore.getState().focusedTileId || DEFAULT_TILES.editor;
+
+      if (matchAction('view.zoomIn', e)) {
         e.preventDefault();
         useUIStore.getState().zoomIn();
         return;
       }
-      // Cmd+- — zoom out
-      if (e.key === '-' && e.metaKey && !e.ctrlKey && !e.altKey) {
+
+      if (matchAction('view.zoomOut', e)) {
         e.preventDefault();
         useUIStore.getState().zoomOut();
         return;
       }
-      // Cmd+0 — reset zoom
-      if (e.key === '0' && e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+
+      if (matchAction('view.resetZoom', e)) {
         e.preventDefault();
         useUIStore.getState().resetZoom();
         return;
       }
 
-      // Cmd+J — toggle terminal
-      if (e.key === 'j' && e.metaKey && !e.shiftKey && !e.ctrlKey) {
+      if (matchAction('nav.nextWorkspace', e)) {
+        e.preventDefault();
+        handleCycleWorkspace('next');
+        return;
+      }
+
+      if (matchAction('nav.prevWorkspace', e)) {
+        e.preventDefault();
+        handleCycleWorkspace('prev');
+        return;
+      }
+
+      for (let slot = 1; slot <= 9; slot += 1) {
+        if (matchAction(`nav.focusWorktree${slot}`, e)) {
+          e.preventDefault();
+          void handleSwitchWorktreeSlot(slot - 1);
+          return;
+        }
+      }
+
+      for (let slot = 1; slot <= 9; slot += 1) {
+        if (matchAction(`nav.focusTab${slot}`, e)) {
+          e.preventDefault();
+          usePanelTabsStore.getState().activateTabByIndex(targetTileId, slot - 1);
+          return;
+        }
+      }
+
+      if (matchAction('view.toggleTerminal', e)) {
         e.preventDefault();
         handleToggleTerminal();
         return;
       }
 
-      // Ctrl+Shift+` — new terminal session
-      // Use e.code because Shift+` produces '~' as e.key
-      if (e.code === 'Backquote' && e.ctrlKey && e.shiftKey) {
+      if (matchAction('view.toggleSidebar', e)) {
         e.preventDefault();
-        const cwd = useFileExplorerStore.getState().rootPath ?? undefined;
-        // Open terminal panel if closed, then create new terminal
-        if (!useUIStore.getState().terminalPanelOpen) {
-          useUIStore.getState().toggleTerminalPanel();
-        }
-        createTerminal(cwd)
-          .then(({ id, shell }) => {
-            useTerminalStore.getState().addTerminal(id, cwd, shell);
-          })
-          .catch((err) => console.error('Failed to create terminal:', err));
+        useUIStore.getState().toggleLeftSidebar();
         return;
       }
-      // Cmd+, — toggle settings
-      if (e.key === ',' && e.metaKey) {
+
+      if (matchAction('terminal.newSession', e)) {
+        e.preventDefault();
+        handleCreateTerminal();
+        return;
+      }
+
+      if (matchAction('settings.open', e)) {
         e.preventDefault();
         if (settingsOpen) {
           closeSettings();
@@ -258,8 +355,7 @@ function AppContent() {
         return;
       }
 
-      // Cmd+N — new agent session
-      if (e.key === 'n' && e.metaKey && !e.shiftKey && !e.ctrlKey) {
+      if (matchAction('agent.newSession', e)) {
         e.preventDefault();
         // Don't create sessions when workspace layout isn't visible
         const currentRootPath = useFileExplorerStore.getState().rootPath;
@@ -275,27 +371,21 @@ function AppContent() {
         return;
       }
 
-      // Cmd+? (Cmd+Shift+/) -- toggle keyboard shortcuts overlay
-      if (e.key === '?' && e.metaKey) {
+      if (matchAction('view.showShortcuts', e)) {
         e.preventDefault();
         setShortcutsOverlayOpen((prev) => !prev);
         return;
       }
 
-      // Cmd+Shift+T -- toggle tab switcher
-      if (e.key === 'T' && e.metaKey && e.shiftKey) {
+      if (matchAction('nav.tabSwitcher', e)) {
         e.preventDefault();
         setTabSwitcherOpen((prev) => !prev);
         return;
       }
 
-      // Cmd+W — close current tab (terminal or panel)
-      if (e.key === 'w' && e.metaKey && !e.shiftKey) {
+      if (matchAction('file.closeTab', e)) {
         e.preventDefault();
-        const isTermOpen = useUIStore.getState().terminalPanelOpen;
-        const isEditorActive = document.activeElement?.closest('.monaco-editor');
-
-        if (isTermOpen && !isEditorActive) {
+        if (isTerminalOpen && !isEditorFocused) {
           // Terminal is open and editor is NOT focused → close terminal tab
           const { activeTerminalId: aid } = useTerminalStore.getState();
           if (aid) {
@@ -306,53 +396,47 @@ function AppContent() {
             }
           }
         } else {
-          // Close the active panel tab in the editor tile
-          usePanelTabsStore.getState().closeActiveTab(DEFAULT_TILES.editor);
+          // Close the active panel tab in the focused tile
+          usePanelTabsStore.getState().closeActiveTab(targetTileId);
         }
         return;
       }
 
-      // Terminal-specific shortcuts (only when terminal panel is open)
-      const isTerminalOpen = useUIStore.getState().terminalPanelOpen;
-      if (!isTerminalOpen) return;
-
-      // A6: Don't intercept shortcuts when Monaco editor is focused
-      const isEditorFocused = document.activeElement?.closest('.monaco-editor');
-      if (isEditorFocused) return;
-
-      // Cmd+T — new terminal
-      if (e.key === 't' && e.metaKey && !e.shiftKey) {
+      if (matchAction('nav.prevTab', e)) {
         e.preventDefault();
-        const cwd = useFileExplorerStore.getState().rootPath ?? undefined;
-        createTerminal(cwd)
-          .then(({ id, shell }) => {
-            useTerminalStore.getState().addTerminal(id, cwd, shell);
-          })
-          .catch((err) => console.error('Failed to create terminal:', err));
+        if (isTerminalOpen && !isEditorFocused) {
+          useTerminalStore.getState().cycleTerminal('prev');
+        } else {
+          usePanelTabsStore.getState().activatePrevTab(targetTileId);
+        }
         return;
       }
 
-      // Cmd+Shift+[ or ] — switch terminal tabs
-      if (e.key === '[' && e.metaKey && e.shiftKey) {
+      if (matchAction('nav.nextTab', e)) {
         e.preventDefault();
-        useTerminalStore.getState().cycleTerminal('prev');
-        return;
-      }
-      if (e.key === ']' && e.metaKey && e.shiftKey) {
-        e.preventDefault();
-        useTerminalStore.getState().cycleTerminal('next');
+        if (isTerminalOpen && !isEditorFocused) {
+          useTerminalStore.getState().cycleTerminal('next');
+        } else {
+          usePanelTabsStore.getState().activateNextTab(targetTileId);
+        }
         return;
       }
 
-      // Cmd+K — clear terminal
-      if (e.key === 'k' && e.metaKey && !e.shiftKey) {
+      if (matchAction('terminal.new', e)) {
+        e.preventDefault();
+        handleCreateTerminal();
+        return;
+      }
+
+      if (!isTerminalOpen || isEditorFocused) return;
+
+      if (matchAction('terminal.clear', e)) {
         e.preventDefault();
         clearActiveTerminal();
         return;
       }
 
-      // Cmd+F — find in terminal
-      if (e.key === 'f' && e.metaKey && !e.shiftKey) {
+      if (matchAction('editor.find', e)) {
         e.preventDefault();
         findInActiveTerminal();
         return;
@@ -360,7 +444,16 @@ function AppContent() {
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [handleToggleTerminal, settingsOpen, openSettings, closeSettings]);
+  }, [
+    closeSettings,
+    handleCreateTerminal,
+    handleCycleWorkspace,
+    handleSwitchWorktreeSlot,
+    handleToggleTerminal,
+    matchAction,
+    openSettings,
+    settingsOpen,
+  ]);
 
   // Open a file in the panel system
   const handleFileOpen = useCallback((path: string) => {

--- a/apps/desktop/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/desktop/src/components/KeyboardShortcutsOverlay.tsx
@@ -7,7 +7,7 @@ import {
 } from './ui/dialog';
 import {
   KEYBINDING_CATEGORIES,
-  DEFAULT_KEYBINDINGS,
+  buildEffectiveKeybindings,
   formatKeybinding,
 } from '@/lib/keybindings/registry';
 import { useSettingsStore } from '@/stores/settingsStore';
@@ -27,13 +27,10 @@ export const KeyboardShortcutsOverlay = ({
   const customKeybindings = useSettingsStore((s) => s.shortcuts.keybindings);
 
   // Build effective keybindings (custom overrides merged with defaults)
-  const effectiveKeybindings = useMemo(() => {
-    const result: Record<string, string> = {};
-    for (const def of DEFAULT_KEYBINDINGS) {
-      result[def.id] = customKeybindings[def.id] ?? def.defaultKey;
-    }
-    return result;
-  }, [customKeybindings]);
+  const effectiveKeybindings = useMemo(
+    () => buildEffectiveKeybindings(customKeybindings),
+    [customKeybindings]
+  );
 
   // Filter categories based on search
   const filteredCategories = useMemo(() => {

--- a/apps/desktop/src/components/panels/MosaicLayout.tsx
+++ b/apps/desktop/src/components/panels/MosaicLayout.tsx
@@ -1,23 +1,22 @@
 /**
  * MosaicLayout - Root component for the panel system
- * Wraps react-mosaic with DnD provider and renders TabbedContainers
+ * Wraps react-mosaic with DnD provider and renders TabbedContainers.
+ * Global keyboard shortcuts are handled in App.tsx so the shortcut registry,
+ * settings UI, and runtime behavior stay aligned.
  */
 
 import { useCallback, useEffect, useMemo } from 'react';
 import { MosaicWithoutDragDropContext, MosaicBranch } from 'react-mosaic-component';
-import { usePanelLayoutStore, useFocusedTileId } from '@/stores/panelLayoutStore';
-import { usePanelTabsStore } from '@/stores/panelTabsStore';
+import { usePanelLayoutStore } from '@/stores/panelLayoutStore';
 import { TabbedContainer } from './TabbedContainer';
 import { usePersistence } from '@/lib/panels/usePersistence';
 import type { TileId, MosaicTree } from '@/lib/panels/types';
-import { DEFAULT_TILES } from '@/lib/panels/constants';
 
 export function MosaicLayout() {
   // Enable layout persistence (load on mount, save on changes)
   usePersistence();
 
   const mosaicTree = usePanelLayoutStore((state) => state.mosaicTree);
-  const focusedTileId = useFocusedTileId();
 
   // Get actions directly from store to avoid selector subscription issues
   const layoutActions = useMemo(() => {
@@ -28,17 +27,7 @@ export function MosaicLayout() {
     };
   }, []);
 
-  const tabActions = useMemo(() => {
-    const state = usePanelTabsStore.getState();
-    return {
-      activateNextTab: state.activateNextTab,
-      activatePrevTab: state.activatePrevTab,
-      activateTabByIndex: state.activateTabByIndex,
-    };
-  }, []);
-
   const { setMosaicTree, initializeDefaultLayout } = layoutActions;
-  const { activateNextTab, activatePrevTab, activateTabByIndex } = tabActions;
 
   // Initialize default layout if no tree exists
   useEffect(() => {
@@ -46,40 +35,6 @@ export function MosaicLayout() {
       initializeDefaultLayout();
     }
   }, [mosaicTree, initializeDefaultLayout]);
-
-  // Keyboard navigation handler
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Determine the target tile (focused or default)
-      const targetTile = focusedTileId || DEFAULT_TILES.editor;
-
-      // Cmd+W is handled globally in App.tsx (supports both terminal + editor tabs)
-
-      // Ctrl+Tab / Ctrl+Shift+Tab - Next/Previous tab
-      if (e.ctrlKey && e.key === 'Tab') {
-        e.preventDefault();
-        if (e.shiftKey) {
-          activatePrevTab(targetTile);
-        } else {
-          activateNextTab(targetTile);
-        }
-        return;
-      }
-
-      // Cmd+1-9 - Switch to tab by index
-      if (e.metaKey && e.key >= '1' && e.key <= '9') {
-        e.preventDefault();
-        const index = parseInt(e.key, 10) - 1; // Convert to 0-based index
-        activateTabByIndex(targetTile, index);
-        return;
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [focusedTileId, activateNextTab, activatePrevTab, activateTabByIndex]);
 
   // Handle tree changes from mosaic (e.g., resize, drag)
   const handleChange = useCallback(

--- a/apps/desktop/src/components/settings/controls/KeybindingInput.tsx
+++ b/apps/desktop/src/components/settings/controls/KeybindingInput.tsx
@@ -5,6 +5,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { Cross2Icon, CounterClockwiseClockIcon } from '@radix-ui/react-icons';
 import { Keyboard } from 'lucide-react';
+import { parseKeyboardEvent } from '../../../lib/keybindings';
 
 interface KeybindingInputProps {
   value: string;
@@ -13,29 +14,6 @@ interface KeybindingInputProps {
   onReset?: () => void;
   hasConflict?: boolean;
   conflictMessage?: string;
-}
-
-function formatKeyEvent(e: KeyboardEvent): string {
-  const parts: string[] = [];
-
-  if (e.metaKey) parts.push('Cmd');
-  if (e.ctrlKey) parts.push('Ctrl');
-  if (e.altKey) parts.push('Alt');
-  if (e.shiftKey) parts.push('Shift');
-
-  // Add the key if it's not a modifier
-  const key = e.key;
-  if (!['Meta', 'Control', 'Alt', 'Shift'].includes(key)) {
-    if (key === ' ') {
-      parts.push('Space');
-    } else if (key.length === 1) {
-      parts.push(key.toUpperCase());
-    } else {
-      parts.push(key);
-    }
-  }
-
-  return parts.join('+');
 }
 
 export function KeybindingInput({
@@ -84,14 +62,14 @@ export function KeybindingInput({
       const isModifierOnly = ['Meta', 'Control', 'Alt', 'Shift'].includes(e.key);
 
       if (hasModifier && !isModifierOnly) {
-        const formatted = formatKeyEvent(e);
+        const formatted = parseKeyboardEvent(e);
         onChange(formatted);
         setIsRecording(false);
       }
     };
 
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    window.addEventListener('keydown', handleKeyDown, { capture: true });
+    return () => window.removeEventListener('keydown', handleKeyDown, true);
   }, [isRecording, onChange]);
 
   // Click outside to cancel
@@ -117,6 +95,7 @@ export function KeybindingInput({
           ref={inputRef}
           type="button"
           onClick={handleStartRecording}
+          data-keybinding-recording={isRecording ? 'true' : undefined}
           className={`
             inline-flex items-center gap-2 px-3 py-2 min-w-[140px]
             border rounded-lg text-sm font-mono cursor-pointer

--- a/apps/desktop/src/components/settings/tabs/ShortcutsTab.tsx
+++ b/apps/desktop/src/components/settings/tabs/ShortcutsTab.tsx
@@ -7,8 +7,9 @@ import { MagnifyingGlassIcon, CounterClockwiseClockIcon } from '@radix-ui/react-
 import { useSettingsStore } from '../../../stores/settingsStore';
 import { KeybindingInput } from '../controls';
 import {
-  DEFAULT_KEYBINDINGS,
   KEYBINDING_CATEGORIES,
+  DEFAULT_KEYBINDINGS,
+  buildEffectiveKeybindings,
   getKeybindingConflicts,
   type KeybindingDefinition,
 } from '../../../lib/keybindings/registry';
@@ -21,13 +22,10 @@ export function ShortcutsTab() {
   const resetAllKeybindings = useSettingsStore((s) => s.resetAllKeybindings);
 
   // Build effective keybindings (custom + defaults)
-  const effectiveKeybindings = useMemo(() => {
-    const result: Record<string, string> = {};
-    for (const def of DEFAULT_KEYBINDINGS) {
-      result[def.id] = customKeybindings[def.id] ?? def.defaultKey;
-    }
-    return result;
-  }, [customKeybindings]);
+  const effectiveKeybindings = useMemo(
+    () => buildEffectiveKeybindings(customKeybindings),
+    [customKeybindings]
+  );
 
   // Find conflicts
   const conflicts = useMemo(

--- a/apps/desktop/src/lib/keybindings/index.ts
+++ b/apps/desktop/src/lib/keybindings/index.ts
@@ -1,6 +1,10 @@
 export {
   DEFAULT_KEYBINDINGS,
   KEYBINDING_CATEGORIES,
+  getDefaultKeybinding,
+  getEffectiveKeybinding,
+  buildEffectiveKeybindings,
+  getKeybindingDefinition,
   getKeybindingConflicts,
   normalizeKeybinding,
   formatKeybinding,

--- a/apps/desktop/src/lib/keybindings/registry.ts
+++ b/apps/desktop/src/lib/keybindings/registry.ts
@@ -18,6 +18,31 @@ export interface KeybindingCategory {
   bindings: KeybindingDefinition[];
 }
 
+const TAB_INDEX_KEYBINDINGS: KeybindingDefinition[] = Array.from({ length: 9 }, (_, index) => {
+  const slot = index + 1;
+  return {
+    id: `nav.focusTab${slot}`,
+    label: `Switch to Tab ${slot}`,
+    description: `Activate open tab ${slot}`,
+    defaultKey: `Cmd+${slot}`,
+    category: 'navigation',
+  };
+});
+
+const WORKTREE_SLOT_KEYBINDINGS: KeybindingDefinition[] = Array.from({ length: 9 }, (_, index) => {
+  const slot = index + 1;
+  return {
+    id: `nav.focusWorktree${slot}`,
+    label: `Switch to Worktree ${slot}`,
+    description:
+      slot === 1
+        ? 'Activate the main workspace in the current repository'
+        : `Activate worktree slot ${slot} in the current repository`,
+    defaultKey: `Ctrl+${slot}`,
+    category: 'navigation',
+  };
+});
+
 export const DEFAULT_KEYBINDINGS: KeybindingDefinition[] = [
   // Agent
   { id: 'agent.newSession', label: 'New Agent Session', description: 'Open a new agent session tab', defaultKey: 'Cmd+N', category: 'agent' },
@@ -55,10 +80,15 @@ export const DEFAULT_KEYBINDINGS: KeybindingDefinition[] = [
   { id: 'settings.open', label: 'Open Settings', description: 'Open settings panel', defaultKey: 'Cmd+,', category: 'settings' },
 
   // Navigation
+  { id: 'nav.nextWorkspace', label: 'Next Workspace', description: 'Switch to the next workspace in the repository rail', defaultKey: 'Ctrl+Tab', category: 'navigation' },
+  { id: 'nav.prevWorkspace', label: 'Previous Workspace', description: 'Switch to the previous workspace in the repository rail', defaultKey: 'Ctrl+Shift+Tab', category: 'navigation' },
   { id: 'nav.goToFile', label: 'Go to File', description: 'Quick open file by name', defaultKey: 'Cmd+P', category: 'navigation', implemented: false },
   { id: 'nav.goToLine', label: 'Go to Line', description: 'Jump to a specific line', defaultKey: 'Cmd+G', category: 'navigation', implemented: false },
   { id: 'nav.nextTab', label: 'Next Tab', description: 'Switch to next tab', defaultKey: 'Cmd+Shift+]', category: 'navigation' },
   { id: 'nav.prevTab', label: 'Previous Tab', description: 'Switch to previous tab', defaultKey: 'Cmd+Shift+[', category: 'navigation' },
+  { id: 'nav.tabSwitcher', label: 'Open Tab Switcher', description: 'Search and switch between open tabs', defaultKey: 'Cmd+Shift+T', category: 'navigation' },
+  ...TAB_INDEX_KEYBINDINGS,
+  ...WORKTREE_SLOT_KEYBINDINGS,
   { id: 'nav.goBack', label: 'Go Back', description: 'Navigate back', defaultKey: 'Cmd+Alt+Left', category: 'navigation', implemented: false },
   { id: 'nav.goForward', label: 'Go Forward', description: 'Navigate forward', defaultKey: 'Cmd+Alt+Right', category: 'navigation', implemented: false },
 ];
@@ -155,6 +185,33 @@ export function normalizeKeybinding(key: string): string {
 
   modifiers.sort((a, b) => modifierOrder.indexOf(a) - modifierOrder.indexOf(b));
   return [...modifiers, mainKey].join('+');
+}
+
+export function getKeybindingDefinition(actionId: string): KeybindingDefinition | undefined {
+  return DEFAULT_KEYBINDINGS.find((binding) => binding.id === actionId);
+}
+
+export function getDefaultKeybinding(actionId: string): string {
+  return getKeybindingDefinition(actionId)?.defaultKey ?? '';
+}
+
+export function getEffectiveKeybinding(
+  actionId: string,
+  customKeybindings: Record<string, string>
+): string {
+  return customKeybindings[actionId] ?? getDefaultKeybinding(actionId);
+}
+
+export function buildEffectiveKeybindings(
+  customKeybindings: Record<string, string>
+): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  for (const def of DEFAULT_KEYBINDINGS) {
+    result[def.id] = getEffectiveKeybinding(def.id, customKeybindings);
+  }
+
+  return result;
 }
 
 /**

--- a/apps/desktop/src/lib/keybindings/useKeybindings.ts
+++ b/apps/desktop/src/lib/keybindings/useKeybindings.ts
@@ -4,7 +4,7 @@
 
 import { useEffect, useCallback, useMemo } from 'react';
 import { useSettingsStore } from '../../stores/settingsStore';
-import { DEFAULT_KEYBINDINGS } from './registry';
+import { getEffectiveKeybinding } from './registry';
 import { matchesKeybinding } from './utils';
 
 type KeybindingHandler = () => void;
@@ -20,13 +20,10 @@ export function useKeybinding(
   const customKeybindings = useSettingsStore((s) => s.shortcuts.keybindings);
 
   // Get the effective keybinding (custom or default)
-  const keybinding = useMemo(() => {
-    if (customKeybindings[actionId]) {
-      return customKeybindings[actionId];
-    }
-    const defaultDef = DEFAULT_KEYBINDINGS.find((d) => d.id === actionId);
-    return defaultDef?.defaultKey ?? '';
-  }, [actionId, customKeybindings]);
+  const keybinding = useMemo(
+    () => getEffectiveKeybinding(actionId, customKeybindings),
+    [actionId, customKeybindings]
+  );
 
   useEffect(() => {
     if (!enabled || !keybinding) return;
@@ -57,14 +54,9 @@ export function useKeybindings(
     const map = new Map<string, string>();
 
     for (const actionId of Object.keys(handlers)) {
-      const custom = customKeybindings[actionId];
-      if (custom) {
-        map.set(custom, actionId);
-      } else {
-        const defaultDef = DEFAULT_KEYBINDINGS.find((d) => d.id === actionId);
-        if (defaultDef) {
-          map.set(defaultDef.defaultKey, actionId);
-        }
+      const keybinding = getEffectiveKeybinding(actionId, customKeybindings);
+      if (keybinding) {
+        map.set(keybinding, actionId);
       }
     }
 
@@ -100,11 +92,8 @@ export function useKeybindings(
 export function useEffectiveKeybinding(actionId: string): string {
   const customKeybindings = useSettingsStore((s) => s.shortcuts.keybindings);
 
-  return useMemo(() => {
-    if (customKeybindings[actionId]) {
-      return customKeybindings[actionId];
-    }
-    const defaultDef = DEFAULT_KEYBINDINGS.find((d) => d.id === actionId);
-    return defaultDef?.defaultKey ?? '';
-  }, [actionId, customKeybindings]);
+  return useMemo(
+    () => getEffectiveKeybinding(actionId, customKeybindings),
+    [actionId, customKeybindings]
+  );
 }

--- a/apps/desktop/src/lib/keybindings/utils.test.ts
+++ b/apps/desktop/src/lib/keybindings/utils.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  buildEffectiveKeybindings,
+  getEffectiveKeybinding,
+} from './registry';
+import {
+  matchesKeybinding,
+  parseKeyboardEvent,
+} from './utils';
+
+function keyboardEvent(
+  init: Partial<Pick<KeyboardEvent, 'key' | 'code' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>>
+): KeyboardEvent {
+  return {
+    key: '',
+    code: '',
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...init,
+  } as KeyboardEvent;
+}
+
+describe('keybinding utilities', () => {
+  it('normalizes shifted slash to Cmd+Shift+/', () => {
+    const event = keyboardEvent({
+      key: '?',
+      code: 'Slash',
+      metaKey: true,
+      shiftKey: true,
+    });
+
+    expect(parseKeyboardEvent(event)).toBe('Cmd+Shift+/');
+    expect(matchesKeybinding('Cmd+Shift+/', event)).toBe(true);
+  });
+
+  it('normalizes shifted bracket keys to their unshifted binding tokens', () => {
+    const event = keyboardEvent({
+      key: '}',
+      code: 'BracketRight',
+      metaKey: true,
+      shiftKey: true,
+    });
+
+    expect(parseKeyboardEvent(event)).toBe('Cmd+Shift+]');
+    expect(matchesKeybinding('Cmd+Shift+]', event)).toBe(true);
+  });
+
+  it('normalizes shifted backquote for terminal session shortcuts', () => {
+    const event = keyboardEvent({
+      key: '~',
+      code: 'Backquote',
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(parseKeyboardEvent(event)).toBe('Ctrl+Shift+`');
+    expect(matchesKeybinding('Ctrl+Shift+`', event)).toBe(true);
+  });
+
+  it('lets Cmd+= bindings match the shifted plus key on the same physical key', () => {
+    const event = keyboardEvent({
+      key: '+',
+      code: 'Equal',
+      metaKey: true,
+      shiftKey: true,
+    });
+
+    expect(parseKeyboardEvent(event)).toBe('Cmd+Shift+=');
+    expect(matchesKeybinding('Cmd+=', event)).toBe(true);
+  });
+
+  it('resolves effective keybindings with custom overrides', () => {
+    const customKeybindings = {
+      'nav.nextWorkspace': 'Ctrl+]',
+    };
+
+    expect(getEffectiveKeybinding('nav.nextWorkspace', customKeybindings)).toBe('Ctrl+]');
+
+    const effective = buildEffectiveKeybindings(customKeybindings);
+    expect(effective['nav.nextWorkspace']).toBe('Ctrl+]');
+    expect(effective['nav.focusWorktree1']).toBe('Ctrl+1');
+  });
+});

--- a/apps/desktop/src/lib/keybindings/utils.ts
+++ b/apps/desktop/src/lib/keybindings/utils.ts
@@ -2,26 +2,69 @@
  * Keybinding Utilities - Parse and format keybinding strings
  */
 
-/**
- * Parse a KeyboardEvent into a keybinding string.
- */
-export function parseKeyboardEvent(e: KeyboardEvent): string {
+const CODE_TO_KEY: Record<string, string> = {
+  Backquote: '`',
+  Minus: '-',
+  Equal: '=',
+  BracketLeft: '[',
+  BracketRight: ']',
+  Backslash: '\\',
+  Semicolon: ';',
+  Quote: "'",
+  Comma: ',',
+  Period: '.',
+  Slash: '/',
+  Digit0: '0',
+  Digit1: '1',
+  Digit2: '2',
+  Digit3: '3',
+  Digit4: '4',
+  Digit5: '5',
+  Digit6: '6',
+  Digit7: '7',
+  Digit8: '8',
+  Digit9: '9',
+};
+
+function getEventKey(e: KeyboardEvent): string {
+  if (e.key === ' ') {
+    return 'Space';
+  }
+
+  if (e.key === 'Esc') {
+    return 'Escape';
+  }
+
+  if (e.code in CODE_TO_KEY) {
+    return CODE_TO_KEY[e.code];
+  }
+
+  if (e.key.length === 1) {
+    return e.key.toUpperCase();
+  }
+
+  return e.key;
+}
+
+function getEventModifiers(e: KeyboardEvent, includeShift: boolean = true): string[] {
   const parts: string[] = [];
 
   if (e.metaKey) parts.push('Cmd');
   if (e.ctrlKey) parts.push('Ctrl');
   if (e.altKey) parts.push('Alt');
-  if (e.shiftKey) parts.push('Shift');
+  if (includeShift && e.shiftKey) parts.push('Shift');
 
-  const key = e.key;
+  return parts;
+}
+
+/**
+ * Parse a KeyboardEvent into a keybinding string.
+ */
+export function parseKeyboardEvent(e: KeyboardEvent): string {
+  const parts = getEventModifiers(e);
+  const key = getEventKey(e);
   if (!['Meta', 'Control', 'Alt', 'Shift'].includes(key)) {
-    if (key === ' ') {
-      parts.push('Space');
-    } else if (key.length === 1) {
-      parts.push(key.toUpperCase());
-    } else {
-      parts.push(key);
-    }
+    parts.push(key);
   }
 
   return parts.join('+');
@@ -32,7 +75,20 @@ export function parseKeyboardEvent(e: KeyboardEvent): string {
  */
 export function matchesKeybinding(binding: string, e: KeyboardEvent): boolean {
   const eventKey = parseKeyboardEvent(e);
-  return normalizeForComparison(binding) === normalizeForComparison(eventKey);
+  const normalizedBinding = normalizeForComparison(binding);
+
+  if (normalizedBinding === normalizeForComparison(eventKey)) {
+    return true;
+  }
+
+  // Treat the shifted "+" variant on the "=" key as a match for bindings
+  // stored as Cmd+=, which is how zoom-in is represented in the registry.
+  if (e.code === 'Equal' && e.shiftKey) {
+    const eventWithoutShift = [...getEventModifiers(e, false), getEventKey(e)].join('+');
+    return normalizedBinding === normalizeForComparison(eventWithoutShift);
+  }
+
+  return false;
 }
 
 /**


### PR DESCRIPTION
## What changed

This PR adds a registry-backed shortcut layer for workspace and worktree navigation in the desktop app.

- adds `Ctrl+Tab` / `Ctrl+Shift+Tab` to cycle workspaces in the repo rail
- adds `Ctrl+1..9` to switch worktree slots within the active workspace
- preserves `Cmd+1..9` for open-tab switching
- moves tab/workspace shortcut handling behind the shared keybinding registry so settings and runtime behavior stay aligned
- fixes shifted punctuation matching for bindings like `Cmd+Shift+/`, `Cmd+Shift+]`, and `Ctrl+Shift+``
- adds focused tests for the keybinding parser/matcher

## Why it changed

The app had a mismatch between shortcuts shown in settings and the shortcuts actually wired at runtime. Navigation behavior was split across separate hardcoded handlers, which made shortcut customization drift from the real implementation.

## User impact

Users can now move between workspaces and worktrees directly from the keyboard, while existing tab switching continues to work as expected. The settings and keyboard-shortcuts overlay now reflect the same action definitions used by runtime handling.

## Root cause

Shortcut parsing and dispatch were fragmented. Some navigation keys lived in app-level handlers, some in panel-local handlers, and shifted punctuation bindings were compared using raw `KeyboardEvent.key` values that did not normalize reliably.

## Validation

I could not run the normal desktop checks in this environment because `bun` is not installed in the shell, `gh` is not installed, and the worktree does not have a local TypeScript install available.

Intended checks once the toolchain is available:

- `bun test apps/desktop/src/lib/keybindings/utils.test.ts`
- `bun run --cwd apps/desktop typecheck`