### PR TITLE
[codex] fix infra auth callback routing

### DIFF
--- a/infra/bin/solo.ts
+++ b/infra/bin/solo.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import "source-map-support/register";
+import "source-map-support/register.js";
 import * as cdk from "aws-cdk-lib";
 import { resolveStageConfig } from "../lib/config.js";
 import { SoloAuthStack } from "../lib/auth-stack.js";

--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -9,12 +9,23 @@ import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
 import * as logs from "aws-cdk-lib/aws-logs";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
+import { existsSync } from "node:fs";
 import * as path from "node:path";
 import * as url from "node:url";
 import type { SoloStageConfig } from "./config.js";
 
 const __filename = url.fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+function resolveEntryPath(entryPath: string): string {
+  const abs = path.resolve(__dirname, "..", entryPath);
+  if (existsSync(abs)) return abs;
+  if (entryPath.endsWith(".ts")) {
+    const compiled = abs.replace(/\.ts$/, ".js");
+    if (existsSync(compiled)) return compiled;
+  }
+  return abs;
+}
 
 export interface SoloApiStackProps extends cdk.StackProps {
   readonly config: SoloStageConfig;
@@ -92,7 +103,7 @@ export class SoloApiStack extends cdk.Stack {
         functionName,
         runtime: lambda.Runtime.NODEJS_20_X,
         architecture: lambda.Architecture.ARM_64,
-        entry: path.resolve(__dirname, "..", entryPath),
+        entry: resolveEntryPath(entryPath),
         handler: "handler",
         timeout: cdk.Duration.seconds(10),
         memorySize: 256,

--- a/infra/lib/auth-stack.ts
+++ b/infra/lib/auth-stack.ts
@@ -6,12 +6,23 @@ import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
 import * as logs from "aws-cdk-lib/aws-logs";
 import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
+import { existsSync } from "node:fs";
 import * as path from "node:path";
 import * as url from "node:url";
 import type { SoloStageConfig } from "./config.js";
 
 const __filename = url.fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+function resolveEntryPath(entryPath: string): string {
+  const abs = path.resolve(__dirname, "..", entryPath);
+  if (existsSync(abs)) return abs;
+  if (entryPath.endsWith(".ts")) {
+    const compiled = abs.replace(/\.ts$/, ".js");
+    if (existsSync(compiled)) return compiled;
+  }
+  return abs;
+}
 
 export interface SoloAuthStackProps extends cdk.StackProps {
   readonly config: SoloStageConfig;
@@ -138,6 +149,35 @@ export class SoloAuthStack extends cdk.Stack {
       }
     }
 
+    const previewWebOrigin =
+      config.stage === "prod"
+        ? undefined
+        : "https://solo-web-sachin1801-sachins-projects-a130ba69.vercel.app";
+
+    const callbackUrls = [
+      "soloide://auth/callback",
+      "http://localhost:3000/auth/callback",
+      "https://solo.dev/auth/callback",
+      "https://solo-build.com/auth/callback",
+      "http://localhost:3000/api/auth/callback/cognito",
+      "https://solo.dev/api/auth/callback/cognito",
+      "https://solo-build.com/api/auth/callback/cognito",
+      ...(previewWebOrigin
+        ? [
+            `${previewWebOrigin}/auth/callback`,
+            `${previewWebOrigin}/api/auth/callback/cognito`,
+          ]
+        : []),
+    ];
+
+    const logoutUrls = [
+      "soloide://auth/signout",
+      "http://localhost:3000",
+      "https://solo.dev",
+      "https://solo-build.com",
+      ...(previewWebOrigin ? [previewWebOrigin] : []),
+    ];
+
     this.userPoolClient = this.userPool.addClient("DesktopClient", {
       userPoolClientName: `solo-desktop-${config.stage}`,
       generateSecret: false,
@@ -155,18 +195,8 @@ export class SoloAuthStack extends cdk.Stack {
           cognito.OAuthScope.PROFILE,
           cognito.OAuthScope.COGNITO_ADMIN,
         ],
-        callbackUrls: [
-          "soloide://auth/callback",
-          "http://localhost:3000/auth/callback",
-          "https://solo.dev/auth/callback",
-          "http://localhost:3000/api/auth/callback/cognito",
-          "https://solo.dev/api/auth/callback/cognito",
-        ],
-        logoutUrls: [
-          "soloide://auth/signout",
-          "http://localhost:3000",
-          "https://solo.dev",
-        ],
+        callbackUrls,
+        logoutUrls,
       },
       supportedIdentityProviders: supportedIdps,
       preventUserExistenceErrors: true,
@@ -194,7 +224,7 @@ export class SoloAuthStack extends cdk.Stack {
         functionName: postAuthFnName,
         runtime: lambda.Runtime.NODEJS_20_X,
         architecture: lambda.Architecture.ARM_64,
-        entry: path.resolve(__dirname, "..", "lambda/github/postAuth.ts"),
+        entry: resolveEntryPath("lambda/github/postAuth.ts"),
         handler: "handler",
         timeout: cdk.Duration.seconds(10),
         memorySize: 256,

--- a/infra/lib/github-stack.ts
+++ b/infra/lib/github-stack.ts
@@ -9,12 +9,23 @@ import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
 import * as logs from "aws-cdk-lib/aws-logs";
 import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
+import { existsSync } from "node:fs";
 import * as path from "node:path";
 import * as url from "node:url";
 import type { SoloStageConfig } from "./config.js";
 
 const __filename = url.fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+function resolveEntryPath(entryPath: string): string {
+  const abs = path.resolve(__dirname, "..", entryPath);
+  if (existsSync(abs)) return abs;
+  if (entryPath.endsWith(".ts")) {
+    const compiled = abs.replace(/\.ts$/, ".js");
+    if (existsSync(compiled)) return compiled;
+  }
+  return abs;
+}
 
 export interface SoloGitHubStackProps extends cdk.StackProps {
   readonly config: SoloStageConfig;
@@ -106,7 +117,7 @@ export class SoloGitHubStack extends cdk.Stack {
         functionName,
         runtime: lambda.Runtime.NODEJS_20_X,
         architecture: lambda.Architecture.ARM_64,
-        entry: path.resolve(__dirname, "..", entryPath),
+        entry: resolveEntryPath(entryPath),
         handler: "handler",
         timeout: cdk.Duration.seconds(10),
         memorySize: 256,


### PR DESCRIPTION
## What changed
- added Cognito web callback and logout support for `solo-build.com`
- added a stable preview callback/logout origin for the Vercel preview alias used for dev web auth testing
- made the CDK entry-path resolution tolerate compiled `.js` fallbacks for the auth-related Lambda bundles
- fixed the ESM source-map-support import suffix expected by Node ESM

## Why
The website auth flow depended on Cognito callback URLs matching the actual web host exactly. Production needed the `solo-build.com` callback, and dev website testing needed a stable preview host instead of random preview URLs.

## Impact
- production Google/GitHub sign-in can redirect back to the website correctly
- dev website auth can be tested on the stable Vercel preview alias without Cognito `redirect_mismatch`
- CDK synth/deploy is more resilient when running from compiled infra artifacts

## Validation
- `cdk diff SoloAuth-prod`
- deployed `SoloGitHub-prod` and `SoloAuth-prod`
- verified prod Cognito callback/logout URLs through AWS CLI
- verified dev Cognito callback/logout URLs through AWS CLI
